### PR TITLE
RHCLOUD-5297: Added implementation for playbook_run_ack message

### DIFF
--- a/src/handlers/receptor/playbookRunAck.ts
+++ b/src/handlers/receptor/playbookRunAck.ts
@@ -4,7 +4,6 @@ import * as Joi from '@hapi/joi';
 import * as db from '../../db';
 import { Status, PlaybookRunExecutor } from './models';
 
-
 export interface PlaybookRunAck extends SatReceptorResponse {
     playbook_run_id: string;
 }
@@ -30,7 +29,7 @@ export async function handle (message: ReceptorMessage<PlaybookRunAck>) {
     });
 
     if (executors === 0) {
-            log.warn({job_id: message.in_response_to}, 'no executor matched');
-            return;
-        }
+        log.warn({job_id: message.in_response_to}, 'no executor matched');
+        return;
+    }
 }


### PR DESCRIPTION
Added implementation for playbook_run_ack message handling using global framework.  

Also marked a larger shared code snippet that I'll fix up once we push all message implementations to master (marked with comment).

JIRA: https://projects.engineering.redhat.com/browse/RHCLOUD-5297