### PR TITLE
RHCLOUD-5125 Implement a playbook run timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,18 @@ npm run verify
 
 Run `node test/producer.js` to produce a test message and send it to Kafka.
 
+## Cleaner script
+
+In addition to the consumer itself this repository also hosts [a script](./src/cleaner/run.ts) that cleans up `playbook_runs`, `playbook_run_executors` and `playbook_run_systems` that failed to reach a final state. More specifically, it:
+* looks for `playbook_run_systems` that haven't received an updated in more than 6 hours and failed to reach one of the final statuses (success, failure, canceled). These records are set the `canceled` status.
+* looks for `playbook_run_executors` that haven't received an update in more than 15 minutes and did not reach one of the final statuses despite all their `playbook_run_systems` being finished. The status of these records is set based on the status of its systems:
+  * `failure` if any of the systems failed
+  * `canceled` if any of the systems was canceled
+  * `success` otherwise
+* looks for `playbook_runs` that haven't received an update in more than 15 minutes and did not reach one of the final statuses despite their `playbook_run_executors` being finished. The status of these records is set based on the status of its executors:
+  * `failure` if any of the executors failed
+  * `canceled` if any of the executors was canceled
+  * `success` otherwise
+
 ## Contact
 For questions or comments join **#insights-remediations** at ansible.slack.com or contact [Jozef Hartinger](https://github.com/jharting) directly.

--- a/src/cleaner/cleaner.integration.ts
+++ b/src/cleaner/cleaner.integration.ts
@@ -1,0 +1,239 @@
+import '../../test';
+import { insertPlaybookRun, assertSystem, assertExecutor, assertRun } from '../../test/playbookRuns';
+import { cancelSystems, cancelExecutors, cancelRuns } from './queries';
+import * as db from '../db';
+import { Status } from '../handlers/receptor/models';
+
+describe('sat-receptor cleaner script', function () {
+    describe('cancelSystems', function () {
+        [Status.PENDING, Status.RUNNING].forEach(status =>
+            test(`cancels a system that is ${status}`, async () => {
+                const data = await insertPlaybookRun(run => {
+                    run.executors[0].systems[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].systems[0].status = status;
+                });
+
+                await cancelSystems(db.get());
+                await assertSystem(data.executors[0].systems[0].id, Status.CANCELED);
+            })
+        );
+
+        [Status.SUCCESS, Status.FAILURE].forEach(status =>
+            test(`does not cancel a system that is ${status}`, async () => {
+                const data = await insertPlaybookRun(run => {
+                    run.executors[0].systems[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].systems[0].status = status;
+                });
+
+                await cancelSystems(db.get());
+                await assertSystem(data.executors[0].systems[0].id, status);
+            })
+        );
+
+        [Status.PENDING, Status.RUNNING, Status.SUCCESS, Status.FAILURE].forEach(status =>
+            test(`does not cancel a recently updated system that is ${status}`, async () => {
+                const data = await insertPlaybookRun(run => {
+                    run.executors[0].systems[0].updated_at = new Date().toISOString();
+                    run.executors[0].systems[0].status = status;
+                });
+
+                await cancelSystems(db.get());
+                await assertSystem(data.executors[0].systems[0].id, status);
+            })
+        );
+    });
+
+    describe('cancelExecutor', function () {
+        [Status.PENDING, Status.ACKED, Status.RUNNING].forEach(initialStatus =>
+            [Status.SUCCESS, Status.FAILURE, Status.CANCELED].forEach(expectedStatus => {
+                test(`transitions a finished executor from ${initialStatus} to ${expectedStatus}`, async () => {
+                    const data = await insertPlaybookRun(run => {
+                        run.executors[0].updated_at = '2020-01-01 00:00:00.000+00';
+                        run.executors[0].status = initialStatus;
+                        run.executors[0].systems[0].updated_at = '2020-01-01 00:00:00.000+00';
+                        run.executors[0].systems[0].status = expectedStatus;
+                    });
+
+                    await cancelExecutors(db.get());
+                    await assertExecutor(data.executors[0].id, expectedStatus);
+                });
+            })
+        );
+
+        [Status.CANCELED, Status.FAILURE].forEach(expectedStatus =>
+            test(`${expectedStatus} systems determine the executor status`, async () => {
+                const data = await insertPlaybookRun(run => {
+                    run.executors[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].status = Status.RUNNING;
+                    run.executors[0].systems[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].systems[0].status = Status.SUCCESS;
+                    run.executors[0].systems[1].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].systems[1].status = Status.CANCELED;
+                    run.executors[0].systems[2].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].systems[2].status = expectedStatus;
+                }, 1, 3);
+
+                await cancelExecutors(db.get());
+                await assertExecutor(data.executors[0].id, expectedStatus);
+            })
+        );
+
+        [Status.PENDING, Status.RUNNING].forEach(systemStatus =>
+            test(`does not finish an executor if not all systems are finished`, async () => {
+                const data = await insertPlaybookRun(run => {
+                    run.executors[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].status = Status.RUNNING;
+                    run.executors[0].systems[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].systems[0].status = Status.SUCCESS;
+                    run.executors[0].systems[1].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].systems[1].status = Status.SUCCESS;
+                    run.executors[0].systems[2].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].systems[2].status = systemStatus;
+                }, 1, 3);
+
+                await cancelExecutors(db.get());
+                await assertExecutor(data.executors[0].id, Status.RUNNING);
+            })
+        );
+
+        [Status.CANCELED, Status.FAILURE].forEach(systemStatus =>
+            test(`does not finish an already finished executor`, async () => {
+                const data = await insertPlaybookRun(run => {
+                    run.executors[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].status = Status.SUCCESS;
+                    run.executors[0].systems[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].systems[0].status = Status.SUCCESS;
+                    run.executors[0].systems[1].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].systems[1].status = Status.SUCCESS;
+                    run.executors[0].systems[2].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].systems[2].status = systemStatus;
+                }, 1, 3);
+
+                await cancelExecutors(db.get());
+                await assertExecutor(data.executors[0].id, Status.SUCCESS);
+            })
+        );
+
+        [Status.RUNNING, Status.PENDING, Status.ACKED].forEach(status =>
+            test(`does not finish a freshly updated executor`, async () => {
+                const data = await insertPlaybookRun(run => {
+                    run.executors[0].updated_at = new Date().toISOString();
+                    run.executors[0].status = status;
+                    run.executors[0].systems[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].systems[0].status = Status.SUCCESS;
+                });
+
+                await cancelExecutors(db.get());
+                await assertExecutor(data.executors[0].id, status);
+            })
+        );
+    });
+
+    describe('cancelRun', function () {
+        [Status.PENDING, Status.RUNNING].forEach(initialStatus =>
+            [Status.SUCCESS, Status.FAILURE, Status.CANCELED].forEach(expectedStatus => {
+                test(`transitions a finished run from ${initialStatus} to ${expectedStatus}`, async () => {
+                    const data = await insertPlaybookRun(run => {
+                        run.updated_at = '2020-01-01 00:00:00.000+00';
+                        run.status = initialStatus;
+                        run.executors[0].updated_at = '2020-01-01 00:00:00.000+00';
+                        run.executors[0].status = expectedStatus;
+                        run.executors[0].systems[0].updated_at = '2020-01-01 00:00:00.000+00';
+                        run.executors[0].systems[0].status = expectedStatus;
+                    });
+
+                    await cancelRuns(db.get());
+                    await assertRun(data.id, expectedStatus);
+                });
+            })
+        );
+
+        [Status.CANCELED, Status.FAILURE].forEach(expectedStatus =>
+            test(`${expectedStatus} executors determine the run status`, async () => {
+                const data = await insertPlaybookRun(run => {
+                    run.updated_at = '2020-01-01 00:00:00.000+00';
+                    run.status = Status.RUNNING;
+                    run.executors[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].status = Status.SUCCESS;
+                    run.executors[0].systems[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].systems[0].status = Status.SUCCESS;
+                    run.executors[1].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[1].status = Status.SUCCESS;
+                    run.executors[1].systems[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[1].systems[0].status = Status.SUCCESS;
+                    run.executors[2].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[2].status = expectedStatus;
+                    run.executors[2].systems[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[2].systems[0].status = expectedStatus;
+                }, 3, 1);
+
+                await cancelRuns(db.get());
+                await assertRun(data.id, expectedStatus);
+            })
+        );
+
+        [Status.PENDING, Status.ACKED, Status.RUNNING].forEach(executorStatus =>
+            test(`does not finish a run if not all executors are finished`, async () => {
+                const data = await insertPlaybookRun(run => {
+                    run.updated_at = '2020-01-01 00:00:00.000+00';
+                    run.status = Status.RUNNING;
+                    run.executors[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].status = Status.SUCCESS;
+                    run.executors[0].systems[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].systems[0].status = Status.SUCCESS;
+                    run.executors[1].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[1].status = executorStatus;
+                    run.executors[1].systems[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[1].systems[0].status = Status.RUNNING;
+                    run.executors[2].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[2].status = Status.SUCCESS;
+                    run.executors[2].systems[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[2].systems[0].status = Status.SUCCESS;
+                }, 3, 1);
+
+                await cancelRuns(db.get());
+                await assertRun(data.id, Status.RUNNING);
+            })
+        );
+
+        [Status.CANCELED, Status.FAILURE].forEach(executorStatus =>
+            test(`does not finish an already finished run`, async () => {
+                const data = await insertPlaybookRun(run => {
+                    run.updated_at = '2020-01-01 00:00:00.000+00';
+                    run.status = Status.SUCCESS;
+                    run.executors[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].status = Status.SUCCESS;
+                    run.executors[0].systems[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].systems[0].status = Status.SUCCESS;
+                    run.executors[1].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[1].status = executorStatus;
+                    run.executors[1].systems[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[1].systems[0].status = Status.RUNNING;
+                    run.executors[2].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[2].status = Status.SUCCESS;
+                    run.executors[2].systems[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[2].systems[0].status = Status.SUCCESS;
+                }, 3, 1);
+
+                await cancelRuns(db.get());
+                await assertRun(data.id, Status.SUCCESS);
+            })
+        );
+
+        [Status.RUNNING, Status.PENDING].forEach(status =>
+            test(`does not finish a freshly updated run`, async () => {
+                const data = await insertPlaybookRun(run => {
+                    run.updated_at = new Date().toISOString();
+                    run.status = status;
+                    run.executors[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].status = Status.SUCCESS;
+                    run.executors[0].systems[0].updated_at = '2020-01-01 00:00:00.000+00';
+                    run.executors[0].systems[0].status = Status.SUCCESS;
+                });
+
+                await cancelRuns(db.get());
+                await assertRun(data.id, status);
+            })
+        );
+    });
+});

--- a/src/cleaner/config.ts
+++ b/src/cleaner/config.ts
@@ -1,0 +1,126 @@
+import '../config';
+import * as convict from 'convict';
+
+const config = convict({
+    env: {
+        format: ['production', 'development', 'test'],
+        default: 'development',
+        env: 'NODE_ENV'
+    },
+    namespace: {
+        format: String,
+        default: 'local',
+        env: 'NAMESPACE'
+    },
+    commit: {
+        format: String,
+        default: undefined,
+        env: 'OPENSHIFT_BUILD_COMMIT'
+    },
+    logging: {
+        level: {
+            format: String,
+            default: 'trace',
+            env: 'LOG_LEVEL'
+        },
+        pretty: {
+            format: Boolean,
+            default: false,
+            env: 'LOG_PRETTY'
+        }
+    },
+
+    db: {
+        connection: {
+            user: {
+                format: String,
+                default: 'postgres',
+                env: 'DB_USERNAME'
+            },
+            password: {
+                format: String,
+                default: 'remediations',
+                env: 'DB_PASSWORD',
+                sensitive: true
+            },
+            database: {
+                format: String,
+                default: 'remediations_consumer_test',
+                env: 'DB_DATABASE'
+            },
+            host: {
+                format: String,
+                default: '127.0.0.1',
+                env: 'DB_HOST'
+            },
+            ssl: {
+                ca: {
+                    format: 'file',
+                    default: undefined,
+                    env: 'DB_CA',
+                    sensitive: true
+                }
+            }
+        },
+        pool: {
+            min: {
+                format: 'nat',
+                default: 2,
+                env: 'DB_POOL_MIN'
+            },
+            max: {
+                format: 'nat',
+                default: 5,
+                env: 'DB_POOL_MAX'
+            }
+        },
+        ssl: {
+            enabled: {
+                format: Boolean,
+                default: true,
+                env: 'DB_SSL_ENABLED'
+            }
+        }
+    },
+
+    metrics: {
+        prefix: {
+            format: String,
+            default: 'remediations_consumer_',
+            env: 'METRICS_PREFIX'
+        },
+        port: {
+            format: 'nat',
+            default: 9006,
+            env: 'METRICS_PORT'
+        }
+    },
+
+    cleaner: {
+        timeoutSystems: {
+            format: 'nat',
+            default: 3 * 60,
+            env: 'CLEANER_TIMEOUT_SYSTEMS'
+        },
+        timeoutExecutors: {
+            format: 'nat',
+            default: 15,
+            env: 'CLEANER_TIMEOUT_EXECUTORS'
+        },
+        timeoutRuns: {
+            format: 'nat',
+            default: 15,
+            env: 'CLEANER_TIMEOUT_RUNS'
+        },
+        pushGateway: {
+            format: 'url',
+            default: 'http://localhost:9091',
+            env: 'CLEANER_PUSH_GATEWAY'
+        }
+    }
+});
+
+config.validate({ strict: true });
+
+export default config.get();
+export const sanitized = config.toString();

--- a/src/cleaner/probes.ts
+++ b/src/cleaner/probes.ts
@@ -1,0 +1,45 @@
+import * as client from 'prom-client';
+import config from './config';
+import log from '../util/log';
+import * as P from 'bluebird';
+import * as os from 'os';
+
+const logger = log.child({type: 'cleaner'});
+
+function createCounter (name: string, help: string, ...labelNames: string[]) {
+    return new client.Counter({
+        name: `${config.metrics.prefix}${name}`, help, labelNames
+    });
+}
+
+function createGauge (name: string, help: string, ...labelNames: string[]) {
+    return new client.Gauge({
+        name: `${config.metrics.prefix}${name}`, help, labelNames
+    });
+}
+
+const updated = createCounter('updated_total', 'Total number of updated records', 'entity');
+const duration = createGauge('update_duration_seconds', 'Total time spent running the UPDATE command', 'entity');
+
+['systems', 'executors', 'runs'].forEach(value => updated.labels(value).inc(0));
+['systems', 'executors', 'runs'].forEach(value => duration.labels(value).inc(0));
+
+export async function updateEntities (type: 'systems' | 'executors' | 'runs', fn: () => Promise<number>) {
+    const stop = duration.labels(type).startTimer();
+    try {
+        const count = await fn();
+        updated.labels(type).inc(count);
+        logger.info({count}, `updated ${type}`);
+    } finally {
+        stop();
+    }
+}
+
+export async function pushMetrics () {
+    const gateway: any = new client.Pushgateway(config.cleaner.pushGateway);
+    const asyncGateway = P.promisifyAll(gateway);
+
+    const jobName = `${config.namespace}/${os.hostname}`;
+    logger.info({jobName}, 'pushing metrics');
+    await asyncGateway.pushAddAsync({jobName});
+}

--- a/src/cleaner/queries.ts
+++ b/src/cleaner/queries.ts
@@ -1,0 +1,78 @@
+import * as Knex from 'knex';
+import { PlaybookRunSystem, Status, PlaybookRunExecutor, PlaybookRun } from '../handlers/receptor/models';
+import { trim } from './utils';
+
+const NON_FINAL_STATES_SYSTEMS = [Status.PENDING, Status.RUNNING];
+const NON_FINAL_STATES_EXECUTORS = [Status.PENDING, Status.ACKED, Status.RUNNING];
+const FINAL_STATES = [Status.SUCCESS, Status.FAILURE, Status.CANCELED];
+
+const EXECUTOR_FINAL_STATUS_SUBQUERY = trim`
+    (
+        SELECT "status" FROM (
+            SELECT
+                "status"::VARCHAR,
+                (
+                    CASE
+                        WHEN "status" = 'failure' THEN 2
+                        WHEN "status" = 'canceled' THEN 1
+                        ELSE 0
+                    END
+                ) as "result"
+            FROM "playbook_run_systems"
+            WHERE "playbook_run_systems"."playbook_run_executor_id" = "playbook_run_executors"."id"
+            ORDER BY "result" DESC
+            LIMIT 1
+        ) as "status"
+    )::enum_playbook_run_executors_status`;
+
+const RUN_FINAL_STATUS_SUBQUERY = trim`
+    (
+        SELECT "status" FROM (
+            SELECT
+                "executors"."status"::VARCHAR,
+                (
+                    CASE
+                        WHEN "executors"."status" = 'failure' THEN 2
+                        WHEN "executors"."status" = 'canceled' THEN 1
+                        ELSE 0
+                    END
+                ) as "result"
+            FROM "playbook_run_executors" AS "executors"
+            WHERE "playbook_runs"."id" = "executors"."playbook_run_id"
+            ORDER BY "result" DESC
+            LIMIT 1
+        ) as "status"
+    )::enum_playbook_runs_status`;
+
+export function cancelSystems (knex: Knex, timeoutMinutes = 3 * 60) {
+    return knex(PlaybookRunSystem.TABLE)
+    .whereNotIn(PlaybookRunSystem.status, FINAL_STATES)
+    .whereRaw(`updated_at < now() - ? * interval '1 minute'`, [timeoutMinutes])
+    .update({
+        [PlaybookRunSystem.status]: Status.CANCELED
+    });
+}
+
+export function cancelExecutors (knex: Knex, timeoutMinutes = 15) {
+    return knex(PlaybookRunExecutor.TABLE)
+    .whereNotIn(PlaybookRunExecutor.status, FINAL_STATES)
+    .whereNotExists(
+        knex(PlaybookRunSystem.TABLE)
+        .whereIn(PlaybookRunSystem.status, NON_FINAL_STATES_SYSTEMS)
+        .where(PlaybookRunSystem.playbook_run_executor_id, knex.raw('"playbook_run_executors"."id"'))
+    )
+    .whereRaw(`updated_at < now() - ? * interval '1 minute'`, [timeoutMinutes])
+    .update(PlaybookRunExecutor.status, knex.raw(EXECUTOR_FINAL_STATUS_SUBQUERY));
+}
+
+export function cancelRuns (knex: Knex, timeoutMinutes = 15) {
+    return knex(PlaybookRun.TABLE)
+    .whereNotIn(PlaybookRun.status, FINAL_STATES)
+    .whereRaw(`updated_at < now() - ? * interval '1 minute'`, [timeoutMinutes])
+    .whereNotExists(
+        knex(PlaybookRunExecutor.TABLE)
+        .whereIn(PlaybookRunExecutor.status, NON_FINAL_STATES_EXECUTORS)
+        .where(PlaybookRunExecutor.playbook_run_id, knex.raw('"playbook_runs"."id"'))
+    )
+    .update(PlaybookRun.status, knex.raw(RUN_FINAL_STATUS_SUBQUERY));
+}

--- a/src/cleaner/run.ts
+++ b/src/cleaner/run.ts
@@ -1,0 +1,30 @@
+import config, { sanitized } from './config';
+import { start, stop } from '../db';
+import version from '../util/version';
+import log from '../util/log';
+import * as probes from './probes';
+import { cancelSystems, cancelExecutors, cancelRuns } from './queries';
+
+async function run () {
+    log.info({env: config.env}, `${version.full} starting`);
+    log.debug(sanitized, 'configuration');
+    const knex = await start(config.db);
+    log.info('connected to database');
+
+    try {
+        await probes.updateEntities('systems', () => cancelSystems(knex, config.cleaner.timeoutSystems));
+        await probes.updateEntities('executors', () => cancelExecutors(knex, config.cleaner.timeoutExecutors));
+        await probes.updateEntities('runs', () => cancelRuns(knex, config.cleaner.timeoutRuns));
+    } finally {
+        try {
+            await probes.pushMetrics();
+            log.info('metrics sent');
+        } finally {
+            await stop();
+        }
+    }
+}
+
+if (require.main === module) {
+    run();
+}

--- a/src/cleaner/utils.ts
+++ b/src/cleaner/utils.ts
@@ -1,0 +1,6 @@
+/*
+ * Removes newlines and excessive whitespace
+ */
+export function trim(value: TemplateStringsArray) {
+    return value[0].replace(/\n/g, '').replace(/[\s]{2,}/g, ' ');
+}

--- a/test/seeds/playbook_runs.js
+++ b/test/seeds/playbook_runs.js
@@ -1,7 +1,7 @@
 export async function seed (knex) {
-    await knex('playbook_runs').del();
-    await knex('playbook_run_executors').del();
     await knex('playbook_run_systems').del();
+    await knex('playbook_run_executors').del();
+    await knex('playbook_runs').del();
 
     await knex('playbook_runs').insert([{
         id: '88d0ba73-0015-4e7d-a6d6-4b530cbfb5bc',


### PR DESCRIPTION
This adds a script (src/cleaner/run.ts) that looks for :
- playbook_run_systems that haven't received an updated in more than 6 hours and failed to reach one of the final statuses (success, failure, canceled) and moves them to canceled
- playbook_run_executors that haven't received an update in more than 15 minutes and did not reach one of the final statuses despite all their playbook_run_systems having a final status and updates the executor status based on the systems
- playbook_runs that haven't received an update in more than 15 minutes and did not reach one of the final statuses despite their playbook_run_executors having a final status and updates the run status based on the executors