### PR TITLE
RHCLOUD-5975: Remediation Job gets stuck pending

### DIFF
--- a/src/cleaner/config.ts
+++ b/src/cleaner/config.ts
@@ -147,7 +147,7 @@ const config = convict({
     cleaner: {
         timeoutSystems: {
             format: 'nat',
-            default: 3 * 60,
+            default: 1 * 60,
             env: 'CLEANER_TIMEOUT_SYSTEMS'
         },
         timeoutExecutors: {


### PR DESCRIPTION
RHCLOUD-5975: Remediation Job gets stuck pending, changed config from 3 hour timeout to 1 hour timeout.  

JIRA:  https://projects.engineering.redhat.com/browse/RHCLOUD-5975