### PR TITLE
[Quick Fix]:  Added remediation_issues table to remediations-consumer db

### DIFF
--- a/test/migrations/20206025155530_remediation_issues.js
+++ b/test/migrations/20206025155530_remediation_issues.js
@@ -1,0 +1,12 @@
+export function up (knex) {
+    return knex.schema.createTable('remediation_issues', function (table) {
+        table.increments('id').primary();
+        table.string('issue_id').notNullable();
+        table.uuid('remediation_id').notNullable();
+        table.string('resolution');
+    });
+}
+
+export function down (knex) {
+    return knex.schema.dropTable('remediation_issues');
+}

--- a/test/migrations/20206125160430_issue_systems_relation.js
+++ b/test/migrations/20206125160430_issue_systems_relation.js
@@ -1,0 +1,11 @@
+export function up (knex) {
+    return knex.schema.alterTable('remediation_issue_systems', function (table) {
+        table.foreign('remediation_issue_id').references('remediation_issues.id');
+    });
+}
+
+export function down (knex) {
+    return knex.schema.alterTable('remediation_issue_systems', function (table) {
+        table.dropForeign('remediation_issue_id');
+    });
+}

--- a/test/seeds/initial.js
+++ b/test/seeds/initial.js
@@ -2,9 +2,24 @@ const toSchema = ({issue, system}) => ({ remediation_issue_id: issue, system_id:
 
 export async function seed (knex) {
     await knex('remediation_issue_systems').del();
+    await knex('remediation_issues').del();
+
+    await knex('remediation_issues').insert([{
+        remediation_id: '1f12bdfc-8267-492d-a930-92f498fe65b9',
+        issue_id: 'advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074'
+    }, {
+        remediation_id: '1f12bdfc-8267-492d-a930-92f498fe65b9',
+        issue_id: 'vulnerabilities:CVE-2017-5715'
+    }, {
+        remediation_id: '1f12bdfc-8267-492d-a930-92f498fe65b9',
+        issue_id: 'vulnerabilities:CVE-2018-5716'
+    }, {
+        remediation_id: '1f12bdfc-8267-492d-a930-92f498fe65b9',
+        issue_id: 'advisor:CVE_2017_6074_kernel|KERNEL_CVE_2018_6075'
+    }]);
     await knex('remediation_issue_systems').insert([
-        { issue: 1, system: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc', resolved: false },
-        { issue: 2, system: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc', resolved: false },
+        { issue: 1, system: 'dde971ae-0a39-4c2b-9041-a92e2d5a96aa', resolved: false },
+        { issue: 2, system: 'dde971ae-0a39-4c2b-9041-a92e2d5a96bb', resolved: false },
         { issue: 3, system: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc', resolved: false },
         { issue: 4, system: 'aa94b090-ea16-46ed-836d-5f42a918e9c7', resolved: false }
     ].map(toSchema));


### PR DESCRIPTION
In order to write tests for the new remediation update logic I had to migrate the remediation_issues table and connect it to the remediation_issue_systems table.