### PR TITLE
RHCLOUD-6844: Handlers for app updates

### DIFF
--- a/src/cleaner/cleaner.integration.ts
+++ b/src/cleaner/cleaner.integration.ts
@@ -2,7 +2,7 @@ import '../../test';
 import { insertPlaybookRun, assertSystem, assertExecutor, assertRun } from '../../test/playbookRuns';
 import { cancelSystems, cancelExecutors, cancelRuns } from './queries';
 import * as db from '../db';
-import { Status } from '../handlers/receptor/models';
+import { Status } from '../handlers/models';
 
 describe('sat-receptor cleaner script', function () {
     describe('cancelSystems', function () {

--- a/src/cleaner/queries.ts
+++ b/src/cleaner/queries.ts
@@ -1,5 +1,5 @@
 import * as Knex from 'knex';
-import { PlaybookRunSystem, Status } from '../handlers/receptor/models';
+import { PlaybookRunSystem, Status } from '../handlers/models';
 import {
     whereUnfinishedExecutorsWithFinishedSystems,
     updateStatusExecutors,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -160,6 +160,30 @@ const config = convict({
             env: 'KAFKA_LOGGING'
         },
         topics: {
+            advisor: {
+                topic: {
+                    format: String,
+                    default: 'platform.remediation-updates.advisor',
+                    env: 'ADVISOR_TOPIC'
+                },
+                resetOffsets: {
+                    format: Boolean,
+                    default: false,
+                    env: 'ADVISOR_RESET_OFFSETS'
+                }
+            },
+            compliance: {
+                topic: {
+                    format: String,
+                    default: 'platform.remediation-updates.compliance',
+                    env: 'COMPLIANCE_TOPIC'
+                },
+                resetOffsets: {
+                    format: Boolean,
+                    default: false,
+                    env: 'COMPLIANCE_RESET_OFFSETS'
+                }
+            },
             inventory: {
                 topic: {
                     format: String,
@@ -172,6 +196,18 @@ const config = convict({
                     env: 'INVENTORY_RESET_OFFSETS'
                 }
             },
+            patch: {
+                topic: {
+                    format: String,
+                    default: 'platform.remediation-updates.patch',
+                    env: 'PATCH_TOPIC'
+                },
+                resetOffsets: {
+                    format: Boolean,
+                    default: false,
+                    env: 'PATCH_RESET_OFFSETS'
+                }
+            },
             receptor: {
                 topic: {
                     format: String,
@@ -182,6 +218,18 @@ const config = convict({
                     format: Boolean,
                     default: false,
                     env: 'RECEPTOR_RESET_OFFSETS'
+                }
+            },
+            vulnerability: {
+                topic: {
+                    format: String,
+                    default: 'platform.remediation-updates.vulnerability',
+                    env: 'VULNERABILITY_TOPIC'
+                },
+                resetOffsets: {
+                    format: Boolean,
+                    default: false,
+                    env: 'VULNERABILITY_RESET_OFFSETS'
                 }
             }
         }

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,16 +1,36 @@
+import advisorHandler from './handlers/advisor';
+import complianceHandler from './handlers/compliance';
 import inventoryHandler from './handlers/inventory';
+import patchHandler from './handlers/patch';
 import receptorHandler from './handlers/receptor';
+import vulnerabilityHandler from './handlers/vulnerability';
 import config from './config';
 
 export function formatTopicDetails(): TopicConfig[] {
     return [{
+        topic: config.kafka.topics.advisor.topic,
+        handler: advisorHandler,
+        resetOffsets: config.kafka.topics.advisor.resetOffsets
+    }, {
+        topic: config.kafka.topics.compliance.topic,
+        handler: complianceHandler,
+        resetOffsets: config.kafka.topics.compliance.resetOffsets
+    }, {
         topic: config.kafka.topics.inventory.topic,
         handler: inventoryHandler,
         resetOffsets: config.kafka.topics.inventory.resetOffsets
     }, {
+        topic: config.kafka.topics.patch.topic,
+        handler: patchHandler,
+        resetOffsets: config.kafka.topics.patch.resetOffsets
+    }, {
         topic: config.kafka.topics.receptor.topic,
         handler: receptorHandler,
         resetOffsets: config.kafka.topics.receptor.resetOffsets
+    }, {
+        topic: config.kafka.topics.vulnerability.topic,
+        handler: vulnerabilityHandler,
+        resetOffsets: config.kafka.topics.vulnerability.resetOffsets
     }];
 }
 

--- a/src/handlers/advisor/advisor.integration.ts
+++ b/src/handlers/advisor/advisor.integration.ts
@@ -1,0 +1,121 @@
+import { getSandbox } from '../../../test';
+import handler from '.';
+import * as db from '../../db';
+import * as probes from '../../probes';
+
+describe('advisor handler integration tests', function () {
+    test('update issue', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.advisor',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96aa", "issues": ["advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'advisorUpdateSuccess');
+
+        await handler(message);
+
+        const result = await db.get()('remediation_issue_systems')
+        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96aa' })
+        .where({ remediation_issue_id: '1'});
+
+        result[0].resolved.should.equal(true);
+        spy.callCount.should.equal(1);
+    });
+
+    test('update multiple issues', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.advisor',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96aa", "issues": ["advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074", "advisor:CVE_2017_6074_kernel|KERNEL_CVE_2019_6075"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'advisorUpdateSuccess');
+
+        await handler(message);
+
+        const result1 = await db.get()('remediation_issue_systems')
+        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96aa' })
+        .where({ remediation_issue_id: '1'});
+
+        const result2 = await db.get()('remediation_issue_systems')
+        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96aa' })
+        .where({ remediation_issue_id: '6'});
+
+        result1[0].resolved.should.equal(false);
+        result2[0].resolved.should.equal(true);
+        spy.callCount.should.equal(2);
+    });
+
+    test('does nothing on unknown host', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.advisor',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96ad", "issues": ["advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074"]}',
+            offset: 0,
+            partition: 12,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'advisorUpdateUnknown');
+
+        await handler(message);
+        spy.callCount.should.equal(1);
+    });
+
+    test('does nothing on unknown issue', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.advisor',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96aa", "issues": ["1"]}',
+            offset: 0,
+            partition: 12,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'advisorUpdateUnknown');
+
+        await handler(message);
+        spy.callCount.should.equal(1);
+    });
+
+    test('handles database errors (search)', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.advisor',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96aa", "issues": ["advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074"]}',
+            offset: 0,
+            partition: 12,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'advisorUpdateError');
+        getSandbox().stub(db, 'findHostIssue').throws();
+
+        await handler(message);
+        spy.callCount.should.equal(1);
+    });
+
+    test('handles database errors (update)', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.advisor',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96aa", "issues": ["advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074"]}',
+            offset: 0,
+            partition: 12,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'advisorUpdateError');
+        getSandbox().stub(db, 'updateIssue').throws();
+
+        await handler(message);
+        spy.callCount.should.equal(1);
+    });
+});

--- a/src/handlers/advisor/advisor.unit.ts
+++ b/src/handlers/advisor/advisor.unit.ts
@@ -1,0 +1,67 @@
+import { getSandbox } from '../../../test';
+import handler from '.';
+import * as probes from '../../probes';
+
+describe('advisor handler unit tests', function () {
+    let advisorUpdateErrorParse: any = null;
+
+    beforeEach(() => {
+        advisorUpdateErrorParse = getSandbox().spy(probes, 'advisorUpdateErrorParse');
+    });
+
+    test('parses a message', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.advisor',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc", "issues": ["advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        advisorUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('parses a message with extra field', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.advisor',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc", "issues": ["advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074"], "foo": "bar"}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        advisorUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('throws error on missing field', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.advisor',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc"}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        advisorUpdateErrorParse.callCount.should.equal(1);
+    });
+
+    test('throws error on invalid JSON', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.advisor',
+            value: '{"host_id": "dde971ae-0a39-4c2b-904',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        advisorUpdateErrorParse.callCount.should.equal(1);
+    });
+});

--- a/src/handlers/advisor/index.ts
+++ b/src/handlers/advisor/index.ts
@@ -1,0 +1,56 @@
+import * as Joi from '@hapi/joi';
+import * as probes from '../../probes';
+import * as db from '../../db';
+import * as P from 'bluebird';
+import * as _ from 'lodash';
+import { Message } from 'kafka-node';
+import { validate, parse } from '../common';
+
+interface AdvisorUpdate {
+    host_id: string;
+    issues: Array<string>;
+}
+
+const schema = Joi.object().keys({
+    host_id: Joi.string().required(),
+    issues: Joi.array().items(Joi.string()).required()
+});
+
+function parseMessage (message: Message): AdvisorUpdate | undefined {
+    try {
+        const parsed = parse(message);
+
+        if (!parsed) {
+            return;
+        }
+
+        return validate(parsed, schema);
+    } catch (e) {
+        probes.advisorUpdateErrorParse(message, e);
+    }
+}
+
+export default async function onMessage (message: Message) {
+    const knex = db.get();
+    const parsed = parseMessage(message);
+    if (!parsed) {
+        return;
+    }
+
+    const { host_id, issues } = parsed;
+
+    for (const issue of issues) {
+        try {
+            const searchResult = await db.findHostIssue(knex, host_id, issue);
+
+            if (searchResult.length > 0) {
+                const updateResult = await db.updateIssue(knex, host_id, searchResult[0].id);
+                probes.advisorUpdateSuccess(host_id, issue, updateResult);
+            } else {
+                probes.advisorUpdateUnknown(host_id, issue);
+            }
+        } catch (e) {
+            probes.advisorUpdateError(host_id, issue, e);
+        }
+    }
+}

--- a/src/handlers/compliance/compliance.integration.ts
+++ b/src/handlers/compliance/compliance.integration.ts
@@ -1,0 +1,122 @@
+import { getSandbox } from '../../../test';
+import handler from '.';
+import * as db from '../../db';
+import * as probes from '../../probes';
+
+describe('compliance handler integration tests', function () {
+    test('update issue', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.compliance',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96bb", "issues": ["ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_disabled"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'complianceUpdateSuccess');
+
+        await handler(message);
+
+        const result = await db.get()('remediation_issue_systems')
+        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96bb' })
+        .where({ remediation_issue_id: '2'});
+
+        result[0].resolved.should.equal(true);
+        spy.callCount.should.equal(1);
+    });
+
+    test('update multiple issues', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.compliance',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96bb", "issues": ["ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_disabled", "ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_rsylog_enabled"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'complianceUpdateSuccess');
+
+        await handler(message);
+
+        const result1 = await db.get()('remediation_issue_systems')
+        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96bb' })
+        .where({ remediation_issue_id: '2'});
+
+        const result2 = await db.get()('remediation_issue_systems')
+        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96bb' })
+        .where({ remediation_issue_id: '7'});
+
+        result1[0].resolved.should.equal(false);
+        result2[0].resolved.should.equal(true);
+
+        spy.callCount.should.equal(2);
+    });
+
+    test('does nothing on unknown host', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.compliance',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96ad", "issues": ["ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_disabled"]}',
+            offset: 0,
+            partition: 12,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'complianceUpdateUnknown');
+
+        await handler(message);
+        spy.callCount.should.equal(1);
+    });
+
+    test('does nothing on unknown issue', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.compliance',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96bb", "issues": ["1"]}',
+            offset: 0,
+            partition: 12,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'complianceUpdateUnknown');
+
+        await handler(message);
+        spy.callCount.should.equal(1);
+    });
+
+    test('handles database errors (search)', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.compliance',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96bb", "issues": ["ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_disabled"]}',
+            offset: 0,
+            partition: 12,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'complianceUpdateError');
+        getSandbox().stub(db, 'findHostIssue').throws();
+
+        await handler(message);
+        spy.callCount.should.equal(1);
+    });
+
+    test('handles database errors (update)', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.compliance',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96bb", "issues": ["ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_disabled"]}',
+            offset: 0,
+            partition: 12,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'complianceUpdateError');
+        getSandbox().stub(db, 'updateIssue').throws();
+
+        await handler(message);
+        spy.callCount.should.equal(1);
+    });
+});

--- a/src/handlers/compliance/compliance.unit.ts
+++ b/src/handlers/compliance/compliance.unit.ts
@@ -1,0 +1,67 @@
+import { getSandbox } from '../../../test';
+import handler from '.';
+import * as probes from '../../probes';
+
+describe('compliance handler unit tests', function () {
+    let complianceUpdateErrorParse: any = null;
+
+    beforeEach(() => {
+        complianceUpdateErrorParse = getSandbox().spy(probes, 'complianceUpdateErrorParse');
+    });
+
+    test('parses a message', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.compliance',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc", "issues": ["ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_disabled"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        complianceUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('parses a message with extra field', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.compliance',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc", "issues": ["ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_disabled"], "foo": "bar"}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        complianceUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('throws error on missing field', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.compliance',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc"}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        complianceUpdateErrorParse.callCount.should.equal(1);
+    });
+
+    test('throws error on invalid JSON', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.compliance',
+            value: '{"host_id": "dde971ae-0a39-4c2b-904',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        complianceUpdateErrorParse.callCount.should.equal(1);
+    });
+});

--- a/src/handlers/compliance/index.ts
+++ b/src/handlers/compliance/index.ts
@@ -1,0 +1,56 @@
+import * as Joi from '@hapi/joi';
+import * as probes from '../../probes';
+import * as db from '../../db';
+import * as P from 'bluebird';
+import * as _ from 'lodash';
+import { Message } from 'kafka-node';
+import { validate, parse } from '../common';
+
+interface ComplianceUpdate {
+    host_id: string;
+    issues: Array<string>;
+}
+
+const schema = Joi.object().keys({
+    host_id: Joi.string().required(),
+    issues: Joi.array().items(Joi.string()).required()
+});
+
+function parseMessage (message: Message): ComplianceUpdate | undefined {
+    try {
+        const parsed = parse(message);
+
+        if (!parsed) {
+            return;
+        }
+
+        return validate(parsed, schema);
+    } catch (e) {
+        probes.complianceUpdateErrorParse(message, e);
+    }
+}
+
+export default async function onMessage (message: Message) {
+    const knex = db.get();
+    const parsed = parseMessage(message);
+    if (!parsed) {
+        return;
+    }
+
+    const { host_id, issues } = parsed;
+
+    for (const issue of issues) {
+        try {
+            const searchResult = await db.findHostIssue(knex, host_id, issue);
+
+            if (searchResult.length > 0) {
+                const updateResult = await db.updateIssue(knex, host_id, searchResult[0].id);
+                probes.complianceUpdateSuccess(host_id, issue, updateResult);
+            } else {
+                probes.complianceUpdateUnknown(host_id, issue);
+            }
+        } catch (e) {
+            probes.complianceUpdateError(host_id, issue, e);
+        }
+    }
+}

--- a/src/handlers/inventory/index.ts
+++ b/src/handlers/inventory/index.ts
@@ -1,10 +1,10 @@
-import * as db from '../db';
-import log from '../util/log';
+import * as db from '../../db';
+import log from '../../util/log';
 import * as Joi from '@hapi/joi';
-import * as probes from '../probes';
+import * as probes from '../../probes';
 import { Message } from 'kafka-node';
-import config from '../config';
-import { validate, parse } from './common';
+import config from '../../config';
+import { validate, parse } from '../common';
 
 interface RemoveMessage {
     id: string;

--- a/src/handlers/inventory/inventory.integration.ts
+++ b/src/handlers/inventory/inventory.integration.ts
@@ -1,10 +1,10 @@
 /* eslint-disable max-len */
 
-import { getSandbox } from '../../test';
-import handler from './inventory';
-import * as db from '../db';
-import * as probes from '../probes';
-import config from '../config';
+import { getSandbox } from '../../../test';
+import handler from '.';
+import * as db from '../../db';
+import * as probes from '../../probes';
+import config from '../../config';
 
 describe('inventory handler integration tests', function () {
     test('removes system references', async () => {

--- a/src/handlers/inventory/inventory.unit.ts
+++ b/src/handlers/inventory/inventory.unit.ts
@@ -1,8 +1,8 @@
 /* eslint-disable max-len */
 
-import { getSandbox } from '../../test';
-import handler from './inventory';
-import * as probes from '../probes';
+import { getSandbox } from '../../../test';
+import handler from '.';
+import * as probes from '../../probes';
 
 describe('inventory handler unit tests', function () {
     let inventoryRemoveErrorParse: any = null;

--- a/src/handlers/models.ts
+++ b/src/handlers/models.ts
@@ -7,6 +7,21 @@ export enum Status {
     CANCELED = 'canceled'
 }
 
+export enum RemediationIssues {
+    TABLE = 'remediation_issues',
+    id = 'id',
+    issue_id = 'issue_id',
+    remediation_id = 'remediation_id',
+    resolution = 'resolution'
+}
+
+export enum RemediationIssueSystems {
+    TABLE = 'remediation_issue_systems',
+    remediation_issue_id = 'remediation_issue_id',
+    system_id = 'system_id',
+    resolved = 'resolved'
+}
+
 export enum PlaybookRun {
     TABLE = 'playbook_runs',
     id = 'id',

--- a/src/handlers/patch/index.ts
+++ b/src/handlers/patch/index.ts
@@ -1,0 +1,56 @@
+import * as Joi from '@hapi/joi';
+import * as probes from '../../probes';
+import * as db from '../../db';
+import * as P from 'bluebird';
+import * as _ from 'lodash';
+import { Message } from 'kafka-node';
+import { validate, parse } from '../common';
+
+interface PatchUpdate {
+    host_id: string;
+    issues: Array<string>;
+}
+
+const schema = Joi.object().keys({
+    host_id: Joi.string().required(),
+    issues: Joi.array().items(Joi.string()).required()
+});
+
+function parseMessage (message: Message): PatchUpdate | undefined {
+    try {
+        const parsed = parse(message);
+
+        if (!parsed) {
+            return;
+        }
+
+        return validate(parsed, schema);
+    } catch (e) {
+        probes.patchUpdateErrorParse(message, e);
+    }
+}
+
+export default async function onMessage (message: Message) {
+    const knex = db.get();
+    const parsed = parseMessage(message);
+    if (!parsed) {
+        return;
+    }
+
+    const { host_id, issues } = parsed;
+
+    for (const issue of issues) {
+        try {
+            const searchResult = await db.findHostIssue(knex, host_id, issue);
+
+            if (searchResult.length > 0) {
+                const updateResult = await db.updateIssue(knex, host_id, searchResult[0].id);
+                probes.patchUpdateSuccess(host_id, issue, updateResult);
+            } else {
+                probes.patchUpdateUnknown(host_id, issue);
+            }
+        } catch (e) {
+            probes.patchUpdateError(host_id, issue, e);
+        }
+    }
+}

--- a/src/handlers/patch/patch.integration.ts
+++ b/src/handlers/patch/patch.integration.ts
@@ -1,0 +1,121 @@
+import { getSandbox } from '../../../test';
+import handler from '.';
+import * as db from '../../db';
+import * as probes from '../../probes';
+
+describe('patch handler integration tests', function () {
+    test('update issue', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.patch',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc", "issues": ["patch:RHBA-2019:0689"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'patchUpdateSuccess');
+
+        await handler(message);
+
+        const result = await db.get()('remediation_issue_systems')
+        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc' })
+        .where({ remediation_issue_id: '3'});
+
+        result[0].resolved.should.equal(true);
+        spy.callCount.should.equal(1);
+    });
+
+    test('update multiple issues', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.patch',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc", "issues": ["patch:RHBA-2019:0689", "patch:RHBA-2019:4105"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'patchUpdateSuccess');
+
+        await handler(message);
+
+        const result1 = await db.get()('remediation_issue_systems')
+        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc' })
+        .where({ remediation_issue_id: '3'});
+
+        const result2 = await db.get()('remediation_issue_systems')
+        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc' })
+        .where({ remediation_issue_id: '8'});
+
+        result1[0].resolved.should.equal(false);
+        result2[0].resolved.should.equal(true);
+        spy.callCount.should.equal(2);
+    });
+
+    test('does nothing on unknown host', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.patch',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96ad", "issues": ["patch:RHBA-2019:0689"]}',
+            offset: 0,
+            partition: 12,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'patchUpdateUnknown');
+
+        await handler(message);
+        spy.callCount.should.equal(1);
+    });
+
+    test('does nothing on unknown issue', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.patch',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc", "issues": ["1"]}',
+            offset: 0,
+            partition: 12,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'patchUpdateUnknown');
+
+        await handler(message);
+        spy.callCount.should.equal(1);
+    });
+
+    test('handles database errors (search)', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.patch',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc", "issues": ["patch:RHBA-2019:0689"]}',
+            offset: 0,
+            partition: 12,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'patchUpdateError');
+        getSandbox().stub(db, 'findHostIssue').throws();
+
+        await handler(message);
+        spy.callCount.should.equal(1);
+    });
+
+    test('handles database errors (update)', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.patch',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc", "issues": ["patch:RHBA-2019:0689"]}',
+            offset: 0,
+            partition: 12,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'patchUpdateError');
+        getSandbox().stub(db, 'updateIssue').throws();
+
+        await handler(message);
+        spy.callCount.should.equal(1);
+    });
+});

--- a/src/handlers/patch/patch.unit.ts
+++ b/src/handlers/patch/patch.unit.ts
@@ -1,0 +1,67 @@
+import { getSandbox } from '../../../test';
+import handler from '.';
+import * as probes from '../../probes';
+
+describe('patch handler unit tests', function () {
+    let patchUpdateErrorParse: any = null;
+
+    beforeEach(() => {
+        patchUpdateErrorParse = getSandbox().spy(probes, 'patchUpdateErrorParse');
+    });
+
+    test('parses a message', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.patch',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc", "issues": ["patch:RHBA-2019:0689"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        patchUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('parses a message with extra field', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.patch',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc", "issues": ["patch:RHBA-2019:0689"], "foo": "bar"}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        patchUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('throws error on missing field', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.patch',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc"}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        patchUpdateErrorParse.callCount.should.equal(1);
+    });
+
+    test('throws error on invalid JSON', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.patch',
+            value: '{"host_id": "dde971ae-0a39-4c2b-904',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        patchUpdateErrorParse.callCount.should.equal(1);
+    });
+});

--- a/src/handlers/receptor/playbookRunAck.ts
+++ b/src/handlers/receptor/playbookRunAck.ts
@@ -3,7 +3,7 @@ import {SatReceptorResponse, ReceptorMessage} from '.';
 import * as Joi from '@hapi/joi';
 import * as db from '../../db';
 import * as probes from '../../probes';
-import { Status } from './models';
+import { Status } from '../models';
 import { updateExecutorByReceptorIds } from './queries';
 
 export interface PlaybookRunAck extends SatReceptorResponse {

--- a/src/handlers/receptor/playbookRunFinished.ts
+++ b/src/handlers/receptor/playbookRunFinished.ts
@@ -4,7 +4,7 @@ import * as db from '../../db';
 import {SatReceptorResponse, ReceptorMessage} from '.';
 import * as Joi from '@hapi/joi';
 import * as probes from '../../probes';
-import { PlaybookRunExecutor, PlaybookRunSystem, Status, PlaybookRun } from './models';
+import { PlaybookRunExecutor, PlaybookRunSystem, Status, PlaybookRun } from '../models';
 import * as Knex from 'knex';
 import { findExecutorByReceptorIds } from './queries';
 import {

--- a/src/handlers/receptor/playbookRunUpdate.ts
+++ b/src/handlers/receptor/playbookRunUpdate.ts
@@ -4,7 +4,7 @@ import {SatReceptorResponse, ReceptorMessage} from '.';
 import * as Joi from '@hapi/joi';
 import * as db from '../../db';
 import * as probes from '../../probes';
-import { Status } from './models';
+import { Status } from '../models';
 import {updateExecutorById, updatePlaybookRun, findExecutorByReceptorIds, updateSystemFull, updateSystemDiff, updateSystemMissing} from './queries';
 
 const ACTIONABLE_STATUSES = [Status.PENDING, Status.ACKED];

--- a/src/handlers/receptor/queries.ts
+++ b/src/handlers/receptor/queries.ts
@@ -1,5 +1,5 @@
 import * as Knex from 'knex';
-import { PlaybookRunExecutor, PlaybookRunSystem, Status, PlaybookRun } from './models';
+import { PlaybookRunExecutor, PlaybookRunSystem, Status, PlaybookRun } from '../models';
 import { ReceptorMessage } from '.';
 import { PlaybookRunUpdate } from './playbookRunUpdate';
 

--- a/src/handlers/receptor/receptor.integration.ts
+++ b/src/handlers/receptor/receptor.integration.ts
@@ -3,7 +3,7 @@
 import onMessage, { SatReceptorResponse, ReceptorMessage } from '.';
 import {getSandbox} from '../../../test';
 import * as probes from '../../probes';
-import { Status } from './models';
+import { Status } from '../models';
 import { insertPlaybookRun, assertRun, assertExecutor, assertSystem } from '../../../test/playbookRuns';
 
 describe('receptor handler integration tests', function () {

--- a/src/handlers/receptor/sharedQueries.ts
+++ b/src/handlers/receptor/sharedQueries.ts
@@ -1,6 +1,6 @@
 import { trim } from '../../util/strings';
 import * as Knex from 'knex';
-import { PlaybookRunExecutor, PlaybookRunSystem, PlaybookRun, Status } from './models';
+import { PlaybookRunExecutor, PlaybookRunSystem, PlaybookRun, Status } from '../models';
 
 const NON_FINAL_STATES_SYSTEMS = [Status.PENDING, Status.RUNNING];
 const NON_FINAL_STATES_EXECUTORS = [Status.PENDING, Status.ACKED, Status.RUNNING];

--- a/src/handlers/vulnerability/index.ts
+++ b/src/handlers/vulnerability/index.ts
@@ -1,0 +1,56 @@
+import * as Joi from '@hapi/joi';
+import * as probes from '../../probes';
+import * as db from '../../db';
+import * as P from 'bluebird';
+import * as _ from 'lodash';
+import { Message } from 'kafka-node';
+import { validate, parse } from '../common';
+
+interface VulnerabilityUpdate {
+    host_id: string;
+    issues: Array<string>;
+}
+
+const schema = Joi.object().keys({
+    host_id: Joi.string().required(),
+    issues: Joi.array().items(Joi.string()).required()
+});
+
+function parseMessage (message: Message): VulnerabilityUpdate | undefined {
+    try {
+        const parsed = parse(message);
+
+        if (!parsed) {
+            return;
+        }
+
+        return validate(parsed, schema);
+    } catch (e) {
+        probes.vulnerabilityUpdateErrorParse(message, e);
+    }
+}
+
+export default async function onMessage (message: Message) {
+    const knex = db.get();
+    const parsed = parseMessage(message);
+    if (!parsed) {
+        return;
+    }
+
+    const { host_id, issues } = parsed;
+
+    for (const issue of issues) {
+        try {
+            const searchResult = await db.findHostIssue(knex, host_id, issue);
+
+            if (searchResult.length > 0) {
+                const updateResult = await db.updateIssue(knex, host_id, searchResult[0].id);
+                probes.vulnerabilityUpdateSuccess(host_id, issue, updateResult);
+            } else {
+                probes.vulnerabilityUpdateUnknown(host_id, issue);
+            }
+        } catch (e) {
+            probes.vulnerabilityUpdateError(host_id, issue, e);
+        }
+    }
+}

--- a/src/handlers/vulnerability/vulnerability.integration.ts
+++ b/src/handlers/vulnerability/vulnerability.integration.ts
@@ -1,0 +1,122 @@
+import { getSandbox } from '../../../test';
+import handler from '.';
+import * as db from '../../db';
+import * as probes from '../../probes';
+
+describe('vulnerability handler integration tests', function () {
+    test('update issue', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.vulnerability',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96dd", "issues": ["vulnerabilities:CVE-2018-5716"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'vulnerabilityUpdateSuccess');
+
+        await handler(message);
+
+        const result = await db.get()('remediation_issue_systems')
+        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96dd' })
+        .where({ remediation_issue_id: '4'});
+
+        result[0].resolved.should.equal(true);
+        spy.callCount.should.equal(1);
+    });
+
+    test('update multiple issues', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.vulnerability',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96dd", "issues": ["vulnerabilities:CVE-2018-5716", "vulnerabilities:CVE-2020-5719"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'vulnerabilityUpdateSuccess');
+
+        await handler(message);
+
+        const result1 = await db.get()('remediation_issue_systems')
+        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96dd' })
+        .where({ remediation_issue_id: '4'});
+
+        const result2 = await db.get()('remediation_issue_systems')
+        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96dd' })
+        .where({ remediation_issue_id: '9'});
+
+        result1[0].resolved.should.equal(false);
+        result2[0].resolved.should.equal(true);
+
+        spy.callCount.should.equal(2);
+    });
+
+    test('does nothing on unknown host', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.vulnerability',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96ad", "issues": ["vulnerabilities:CVE-2018-5716"]}',
+            offset: 0,
+            partition: 12,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'vulnerabilityUpdateUnknown');
+
+        await handler(message);
+        spy.callCount.should.equal(1);
+    });
+
+    test('does nothing on unknown issue', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.vulnerability',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96dd", "issues": ["1"]}',
+            offset: 0,
+            partition: 12,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'vulnerabilityUpdateUnknown');
+
+        await handler(message);
+        spy.callCount.should.equal(1);
+    });
+
+    test('handles database errors (search)', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.vulnerability',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96dd", "issues": ["vulnerabilities:CVE-2018-5716"]}',
+            offset: 0,
+            partition: 12,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'vulnerabilityUpdateError');
+        getSandbox().stub(db, 'findHostIssue').throws();
+
+        await handler(message);
+        spy.callCount.should.equal(1);
+    });
+
+    test('handles database errors (update)', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.vulnerability',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96dd", "issues": ["vulnerabilities:CVE-2018-5716"]}',
+            offset: 0,
+            partition: 12,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'vulnerabilityUpdateError');
+        getSandbox().stub(db, 'updateIssue').throws();
+
+        await handler(message);
+        spy.callCount.should.equal(1);
+    });
+});

--- a/src/handlers/vulnerability/vulnerability.unit.ts
+++ b/src/handlers/vulnerability/vulnerability.unit.ts
@@ -1,0 +1,67 @@
+import { getSandbox } from '../../../test';
+import handler from '.';
+import * as probes from '../../probes';
+
+describe('vulnerability handler unit tests', function () {
+    let vulnerabilityUpdateErrorParse: any = null;
+
+    beforeEach(() => {
+        vulnerabilityUpdateErrorParse = getSandbox().spy(probes, 'vulnerabilityUpdateErrorParse');
+    });
+
+    test('parses a message', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.vulnerability',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc", "issues": ["vulnerabilities:CVE-2018-5716"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        vulnerabilityUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('parses a message with extra field', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.vulnerability',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc", "issues": ["vulnerabilities:CVE-2018-5716"], "foo": "bar"}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        vulnerabilityUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('throws error on missing field', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.vulnerability',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc"}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        vulnerabilityUpdateErrorParse.callCount.should.equal(1);
+    });
+
+    test('throws error on invalid JSON', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.vulnerability',
+            value: '{"host_id": "dde971ae-0a39-4c2b-904',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        vulnerabilityUpdateErrorParse.callCount.should.equal(1);
+    });
+});

--- a/src/kafka/index.ts
+++ b/src/kafka/index.ts
@@ -38,7 +38,14 @@ const consumer = P.promisifyAll(new kafka.ConsumerGroupStream({
     autoCommitIntervalMs: 5000,
     protocol: ['roundrobin'],
     highWaterMark: 5
-}, [config.kafka.topics.inventory.topic, config.kafka.topics.receptor.topic]));
+}, [
+    config.kafka.topics.advisor.topic,
+    config.kafka.topics.compliance.topic,
+    config.kafka.topics.inventory.topic,
+    config.kafka.topics.patch.topic,
+    config.kafka.topics.receptor.topic,
+    config.kafka.topics.vulnerability.topic
+]));
 
 async function resetOffsets (topic: string) {
     log.info({ topic }, 'reseting offsets for topic');

--- a/src/probes.ts
+++ b/src/probes.ts
@@ -21,11 +21,20 @@ const counters = {
     executorNotFound: createCounter(
         'receptor_executor_not_found', 'Total number of cases when an executor is not found in a query', 'result'),
     receptorCancelAck: createCounter('receptor_cancel_ack_total', 'Total number of playbook_run_cancel_ack messages', 'status'),
-    lostMessage: createCounter('lost_messages_total', 'Total number of updates lost when in DIFF mode')
+    lostMessage: createCounter('lost_messages_total', 'Total number of updates lost when in DIFF mode'),
+    advisor: createCounter('advisor_total', 'Total number of advisor update messages processed', 'result'),
+    compliance: createCounter('compliance_total', 'Total number of compliance update messages processed', 'result'),
+    patch: createCounter('patch_total', 'Total number of patch update messages processed', 'result'),
+    vulnerability: createCounter(
+        'vulnerability_total', 'Total number of vulnerability update messages processed', 'result')
 };
 
 // https://www.robustperception.io/existential-issues-with-metrics
 ['success', 'unknown', 'error', 'error_parse'].forEach(value => counters.remove.labels(value).inc(0));
+['success', 'unknown', 'error', 'error_parse'].forEach(value => counters.advisor.labels(value).inc(0));
+['success', 'unknown', 'error', 'error_parse'].forEach(value => counters.compliance.labels(value).inc(0));
+['success', 'unknown', 'error', 'error_parse'].forEach(value => counters.patch.labels(value).inc(0));
+['success', 'unknown', 'error', 'error_parse'].forEach(value => counters.vulnerability.labels(value).inc(0));
 ['error', 'error_parse', 'processed'].forEach(value => {
     ['playbook_run_ack', 'playbook_run_update', 'playbook_run_finished', 'playbook_run_cancel_ack', 'unknown'].forEach(type => {
         counters.receptor.labels(value, type).inc(0);
@@ -88,3 +97,83 @@ export function lostUpdateMessage (message: ReceptorMessage<PlaybookRunUpdate>) 
     log.warn({message}, 'lost update message before given message in sequence');
     counters.lostMessage.inc()
 }
+
+export function advisorUpdateSuccess (host_id: string, issue_id: string, references: number) {
+    log.info({ host_id, issue_id, references }, 'advisor issue updated');
+    counters.advisor.labels('success').inc();
+};
+
+export function advisorUpdateUnknown (host_id: string, issue_id: string) {
+    log.debug({ host_id, issue_id }, 'host_id or issue_id not known');
+    counters.advisor.labels('unknown').inc();
+};
+
+export function advisorUpdateError (host_id: string, issue_id: string, err: Error) {
+    log.error({ host_id, issue_id, err }, 'error updating advisor issue');
+    counters.advisor.labels('error').inc();
+};
+
+export function advisorUpdateErrorParse (message: Message, err: Error) {
+    log.error({ message, err }, 'error parsing advisor message');
+    counters.compliance.labels('error_parse').inc();
+};
+
+export function complianceUpdateSuccess (host_id: string, issue_id: string, references: number) {
+    log.info({ host_id, issue_id, references }, 'compliance issue updated');
+    counters.compliance.labels('success').inc();
+};
+
+export function complianceUpdateUnknown (host_id: string, issue_id: string) {
+    log.debug({ host_id, issue_id }, 'host_id or issue_id not known');
+    counters.compliance.labels('unknown').inc();
+};
+
+export function complianceUpdateError (host_id: string, issue_id: string, err: Error) {
+    log.error({ host_id, issue_id, err }, 'error updating compliance issue');
+    counters.compliance.labels('error').inc();
+};
+
+export function complianceUpdateErrorParse (message: Message, err: Error) {
+    log.error({ message, err }, 'error parsing compliance message');
+    counters.compliance.labels('error_parse').inc();
+};
+
+export function patchUpdateSuccess (host_id: string, issue_id: string, references: number) {
+    log.info({ host_id, issue_id, references }, 'patch issue updated');
+    counters.patch.labels('success').inc();
+};
+
+export function patchUpdateUnknown (host_id: string, issue_id: string) {
+    log.debug({ host_id, issue_id }, 'host_id or issue_id not known');
+    counters.patch.labels('unknown').inc();
+};
+
+export function patchUpdateError (host_id: string, issue_id: string, err: Error) {
+    log.error({ host_id, issue_id, err }, 'error updating patch issue');
+    counters.patch.labels('error').inc();
+};
+
+export function patchUpdateErrorParse (message: Message, err: Error) {
+    log.error({ message, err }, 'error parsing patch message');
+    counters.patch.labels('error_parse').inc();
+};
+
+export function vulnerabilityUpdateSuccess (host_id: string, issue_id: string, references: number) {
+    log.info({ host_id, issue_id, references }, 'vulnerability issue updated');
+    counters.vulnerability.labels('success').inc();
+};
+
+export function vulnerabilityUpdateUnknown (host_id: string, issue_id: string) {
+    log.debug({ host_id, issue_id }, 'host_id or issue_id not known');
+    counters.vulnerability.labels('unknown').inc();
+};
+
+export function vulnerabilityUpdateError (host_id: string, issue_id: string, err: Error) {
+    log.error({ host_id, issue_id, err }, 'error updating vulnerability issue');
+    counters.vulnerability.labels('error').inc();
+};
+
+export function vulnerabilityUpdateErrorParse (message: Message, err: Error) {
+    log.error({ message, err }, 'error parsing vulnerability message');
+    counters.vulnerability.labels('error_parse').inc();
+};

--- a/test/playbookRuns.ts
+++ b/test/playbookRuns.ts
@@ -1,5 +1,5 @@
 import {v4} from 'uuid';
-import { Status, PlaybookRunExecutor, PlaybookRun, PlaybookRunSystem } from '../src/handlers/receptor/models';
+import { Status, PlaybookRunExecutor, PlaybookRun, PlaybookRunSystem } from '../src/handlers/models';
 import * as db from '../src/db';
 import * as P from 'bluebird';
 import * as _ from 'lodash';

--- a/test/producer.js
+++ b/test/producer.js
@@ -29,6 +29,34 @@ const messages = [
             in_response_to: '65c0ba21-1015-4e7d-a6d6-4b530cbfb5bd',
             serial: 2
         })
+    },
+    {
+        topic: 'platform.remediation-updates.advisor',
+        messages: JSON.stringify({
+            host_id: 'a910d22d-ff4b-4178-9eec-2f04424983ff',
+            issues: ['advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074', 'advisor:CVE_2017_6074_kernel|KERNEL_CVE_2018_6075']
+        })
+    },
+    {
+        topic: 'platform.remediation-updates.compliance',
+        messages: JSON.stringify({
+            host_id: 'a910d22d-ff4b-4178-9eec-2f04424983ff',
+            issues: ['ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_disabled']
+        })
+    },
+    {
+        topic: 'platform.remediation-updates.patch',
+        messages: JSON.stringify({
+            host_id: 'a910d22d-ff4b-4178-9eec-2f04424983ff',
+            issues: ['patch:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074']
+        })
+    },
+    {
+        topic: 'platform.remediation-updates.vulnerability',
+        messages: JSON.stringify({
+            host_id: 'a910d22d-ff4b-4178-9eec-2f04424983ff',
+            issues: ['vulnerabilities:RHSA-2018:0502', 'vulnerabilities:CVE-2017-5715']
+        })
     }
 ];
 

--- a/test/seeds/initial.js
+++ b/test/seeds/initial.js
@@ -9,18 +9,38 @@ export async function seed (knex) {
         issue_id: 'advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074'
     }, {
         remediation_id: '1f12bdfc-8267-492d-a930-92f498fe65b9',
-        issue_id: 'vulnerabilities:CVE-2017-5715'
+        issue_id: 'ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_disabled'
+    }, {
+        remediation_id: '1f12bdfc-8267-492d-a930-92f498fe65b9',
+        issue_id: 'patch:RHBA-2019:0689'
     }, {
         remediation_id: '1f12bdfc-8267-492d-a930-92f498fe65b9',
         issue_id: 'vulnerabilities:CVE-2018-5716'
     }, {
         remediation_id: '1f12bdfc-8267-492d-a930-92f498fe65b9',
-        issue_id: 'advisor:CVE_2017_6074_kernel|KERNEL_CVE_2018_6075'
+        issue_id: 'vulnerabilities:CVE-2019-5717'
+    }, {
+        remediation_id: '1f12bdfc-8267-492d-a930-92f498fe65b9',
+        issue_id: 'advisor:CVE_2017_6074_kernel|KERNEL_CVE_2019_6075'
+    }, {
+        remediation_id: '1f12bdfc-8267-492d-a930-92f498fe65b9',
+        issue_id: 'ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_rsylog_enabled'
+    }, {
+        remediation_id: '1f12bdfc-8267-492d-a930-92f498fe65b9',
+        issue_id: 'patch:RHBA-2019:4105'
+    }, {
+        remediation_id: '1f12bdfc-8267-492d-a930-92f498fe65b9',
+        issue_id: 'vulnerabilities:CVE-2020-5719'
     }]);
     await knex('remediation_issue_systems').insert([
         { issue: 1, system: 'dde971ae-0a39-4c2b-9041-a92e2d5a96aa', resolved: false },
         { issue: 2, system: 'dde971ae-0a39-4c2b-9041-a92e2d5a96bb', resolved: false },
         { issue: 3, system: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc', resolved: false },
-        { issue: 4, system: 'aa94b090-ea16-46ed-836d-5f42a918e9c7', resolved: false }
+        { issue: 4, system: 'dde971ae-0a39-4c2b-9041-a92e2d5a96dd', resolved: false },
+        { issue: 5, system: 'aa94b090-ea16-46ed-836d-5f42a918e9c7', resolved: false },
+        { issue: 6, system: 'dde971ae-0a39-4c2b-9041-a92e2d5a96aa', resolved: false },
+        { issue: 7, system: 'dde971ae-0a39-4c2b-9041-a92e2d5a96bb', resolved: false },
+        { issue: 8, system: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc', resolved: false },
+        { issue: 9, system: 'dde971ae-0a39-4c2b-9041-a92e2d5a96dd', resolved: false }
     ].map(toSchema));
 }


### PR DESCRIPTION
Created 4 new handlers for the remediation updates from apps ticket.  Each of these handlers will be called when a message is recieved from the 4 corresponding Kafka topics created for this feature.  

Also took some time to refactor the handler folder to make the whole thing easier to navigate.  

doc on remediation updates from apps:  https://docs.google.com/document/d/1UaTDxj0jK-VaAZYzpESIvCAhE5-ST8XZt63PP5dsOIw/edit
JIRA:  https://projects.engineering.redhat.com/browse/RHCLOUD-6844