### PR TITLE
disable application updates until a query efficiency is improved

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -8,29 +8,13 @@ import config from './config';
 
 export function formatTopicDetails(): TopicConfig[] {
     return [{
-        topic: config.kafka.topics.advisor.topic,
-        handler: advisorHandler,
-        resetOffsets: config.kafka.topics.advisor.resetOffsets
-    }, {
-        topic: config.kafka.topics.compliance.topic,
-        handler: complianceHandler,
-        resetOffsets: config.kafka.topics.compliance.resetOffsets
-    }, {
         topic: config.kafka.topics.inventory.topic,
         handler: inventoryHandler,
         resetOffsets: config.kafka.topics.inventory.resetOffsets
     }, {
-        topic: config.kafka.topics.patch.topic,
-        handler: patchHandler,
-        resetOffsets: config.kafka.topics.patch.resetOffsets
-    }, {
         topic: config.kafka.topics.receptor.topic,
         handler: receptorHandler,
         resetOffsets: config.kafka.topics.receptor.resetOffsets
-    }, {
-        topic: config.kafka.topics.vulnerability.topic,
-        handler: vulnerabilityHandler,
-        resetOffsets: config.kafka.topics.vulnerability.resetOffsets
     }];
 }
 

--- a/src/kafka/index.ts
+++ b/src/kafka/index.ts
@@ -39,12 +39,8 @@ const consumer = P.promisifyAll(new kafka.ConsumerGroupStream({
     protocol: ['roundrobin'],
     highWaterMark: 5
 }, [
-    config.kafka.topics.advisor.topic,
-    config.kafka.topics.compliance.topic,
     config.kafka.topics.inventory.topic,
-    config.kafka.topics.patch.topic,
-    config.kafka.topics.receptor.topic,
-    config.kafka.topics.vulnerability.topic
+    config.kafka.topics.receptor.topic
 ]));
 
 async function resetOffsets (topic: string) {


### PR DESCRIPTION
As per the conversation with Jozef I am disabling the consumer's connection to the remediation update topics until I improve the efficiency of the queries.