### PR TITLE
RHCLOUD-8016: Make "update" handlers more efficient

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -15,6 +15,22 @@ export function formatTopicDetails(): TopicConfig[] {
         topic: config.kafka.topics.receptor.topic,
         handler: receptorHandler,
         resetOffsets: config.kafka.topics.receptor.resetOffsets
+    }, {
+        topic: config.kafka.topics.advisor.topic,
+        handler: advisorHandler,
+        resetOffsets: config.kafka.topics.advisor.resetOffsets
+    }, {
+        topic: config.kafka.topics.compliance.topic,
+        handler: complianceHandler,
+        resetOffsets: config.kafka.topics.compliance.resetOffsets
+    }, {
+        topic: config.kafka.topics.patch.topic,
+        handler: patchHandler,
+        resetOffsets: config.kafka.topics.patch.resetOffsets
+    }, {
+        topic: config.kafka.topics.vulnerability.topic,
+        handler: vulnerabilityHandler,
+        resetOffsets: config.kafka.topics.vulnerability.resetOffsets
     }];
 }
 

--- a/src/handlers/advisor/advisor.integration.ts
+++ b/src/handlers/advisor/advisor.integration.ts
@@ -1,3 +1,4 @@
+import { RemediationIssueSystems, RemediationIssues } from '../models';
 import { getSandbox } from '../../../test';
 import handler from '.';
 import * as db from '../../db';
@@ -5,6 +6,29 @@ import * as probes from '../../probes';
 
 describe('advisor handler integration tests', function () {
     test('update issue', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.advisor',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96aa", "issues": ["advisor:CVE_2017_6074_kernel|KERNEL_CVE_2019_6075"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'advisorUpdateSuccess');
+
+        await handler(message);
+
+        const result = await db.get()(RemediationIssueSystems.TABLE)
+        .join(RemediationIssues.TABLE, RemediationIssues.id, RemediationIssueSystems.remediation_issue_id)
+        .where({ [RemediationIssueSystems.system_id]: 'dde971ae-0a39-4c2b-9041-a92e2d5a96aa' })
+        .where({ [RemediationIssues.issue_id]: 'advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074'});
+
+        result[0].resolved.should.equal(true);
+        spy.callCount.should.equal(2);
+    });
+
+    test('update multiple issues', async () => {
         const message = {
             topic: 'platform.remediation-updates.advisor',
             value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96aa", "issues": ["advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074"]}',
@@ -18,35 +42,15 @@ describe('advisor handler integration tests', function () {
 
         await handler(message);
 
-        const result = await db.get()('remediation_issue_systems')
-        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96aa' })
-        .where({ remediation_issue_id: '1'});
+        const result1 = await db.get()(RemediationIssueSystems.TABLE)
+        .join(RemediationIssues.TABLE, RemediationIssues.id, RemediationIssueSystems.remediation_issue_id)
+        .where({ [RemediationIssueSystems.system_id]: 'dde971ae-0a39-4c2b-9041-a92e2d5a96aa' })
+        .where({ [RemediationIssues.issue_id]: 'advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074'});
 
-        result[0].resolved.should.equal(true);
-        spy.callCount.should.equal(1);
-    });
-
-    test('update multiple issues', async () => {
-        const message = {
-            topic: 'platform.remediation-updates.advisor',
-            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96aa", "issues": ["advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074", "advisor:CVE_2017_6074_kernel|KERNEL_CVE_2019_6075"]}',
-            offset: 0,
-            partition: 58,
-            highWaterOffset: 1,
-            key: undefined
-        };
-
-        const spy = getSandbox().spy(probes, 'advisorUpdateSuccess');
-
-        await handler(message);
-
-        const result1 = await db.get()('remediation_issue_systems')
-        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96aa' })
-        .where({ remediation_issue_id: '1'});
-
-        const result2 = await db.get()('remediation_issue_systems')
-        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96aa' })
-        .where({ remediation_issue_id: '6'});
+        const result2 = await db.get()(RemediationIssueSystems.TABLE)
+        .join(RemediationIssues.TABLE, RemediationIssues.id, RemediationIssueSystems.remediation_issue_id)
+        .where({ [RemediationIssueSystems.system_id]: 'dde971ae-0a39-4c2b-9041-a92e2d5a96aa' })
+        .where({ [RemediationIssues.issue_id]: 'advisor:CVE_2017_6074_kernel|KERNEL_CVE_2019_6075'});
 
         result1[0].resolved.should.equal(false);
         result2[0].resolved.should.equal(true);
@@ -63,7 +67,7 @@ describe('advisor handler integration tests', function () {
             key: undefined
         };
 
-        const spy = getSandbox().spy(probes, 'advisorUpdateUnknown');
+        const spy = getSandbox().spy(probes, 'advisorHostUnknown');
 
         await handler(message);
         spy.callCount.should.equal(1);
@@ -79,10 +83,10 @@ describe('advisor handler integration tests', function () {
             key: undefined
         };
 
-        const spy = getSandbox().spy(probes, 'advisorUpdateUnknown');
+        const spy = getSandbox().spy(probes, 'advisorIssueUnknown');
 
         await handler(message);
-        spy.callCount.should.equal(1);
+        spy.callCount.should.equal(2);
     });
 
     test('handles database errors (search)', async () => {
@@ -96,13 +100,13 @@ describe('advisor handler integration tests', function () {
         };
 
         const spy = getSandbox().spy(probes, 'advisorUpdateError');
-        getSandbox().stub(db, 'findHostIssue').throws();
+        getSandbox().stub(db, 'findHostIssues').throws();
 
         await handler(message);
         spy.callCount.should.equal(1);
     });
 
-    test('handles database errors (update)', async () => {
+    test('handles database errors (updateUnresolved)', async () => {
         const message = {
             topic: 'platform.remediation-updates.advisor',
             value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96aa", "issues": ["advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074"]}',
@@ -113,7 +117,24 @@ describe('advisor handler integration tests', function () {
         };
 
         const spy = getSandbox().spy(probes, 'advisorUpdateError');
-        getSandbox().stub(db, 'updateIssue').throws();
+        getSandbox().stub(db, 'updateToUnresolved').throws();
+
+        await handler(message);
+        spy.callCount.should.equal(1);
+    });
+
+    test('handles database errors (updateResolved)', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.advisor',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96aa", "issues": ["advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074"]}',
+            offset: 0,
+            partition: 12,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'advisorUpdateError');
+        getSandbox().stub(db, 'updateToResolved').throws();
 
         await handler(message);
         spy.callCount.should.equal(1);

--- a/src/handlers/advisor/index.ts
+++ b/src/handlers/advisor/index.ts
@@ -38,19 +38,32 @@ export default async function onMessage (message: Message) {
     }
 
     const { host_id, issues } = parsed;
+    try {
+        const pastIssues = await db.findHostIssues(knex, host_id);
 
-    for (const issue of issues) {
-        try {
-            const searchResult = await db.findHostIssue(knex, host_id, issue);
-
-            if (searchResult.length > 0) {
-                const updateResult = await db.updateIssue(knex, host_id, searchResult[0].id);
-                probes.advisorUpdateSuccess(host_id, issue, updateResult);
-            } else {
-                probes.advisorUpdateUnknown(host_id, issue);
-            }
-        } catch (e) {
-            probes.advisorUpdateError(host_id, issue, e);
+        if (_.isEmpty(pastIssues)) {
+            probes.advisorHostUnknown(host_id);
+            return;
         }
+
+        for (const issue of pastIssues) {
+            if (_.find(issues, update => update === issue.issue_id)) {
+                const result = await db.updateToUnresolved(knex, host_id, issue.issue_id);
+
+                if (!_.isEmpty(result)) {
+                    probes.advisorIssueUnknown(host_id, issue.issue_id);
+                }
+                probes.advisorUpdateSuccess(host_id, issue.issue_id, result.length);
+            } else {
+                const result = await db.updateToResolved(knex, host_id, issue.issue_id);
+                
+                if (!_.isEmpty(result)) {
+                    probes.advisorIssueUnknown(host_id, issue.issue_id);
+                }
+                probes.advisorUpdateSuccess(host_id, issue.issue_id, result.length);
+            }
+        }
+    } catch (e) {
+        probes.advisorUpdateError(host_id, issues, e);
     }
 }

--- a/src/handlers/compliance/compliance.integration.ts
+++ b/src/handlers/compliance/compliance.integration.ts
@@ -1,3 +1,4 @@
+import { RemediationIssueSystems, RemediationIssues } from '../models';
 import { getSandbox } from '../../../test';
 import handler from '.';
 import * as db from '../../db';
@@ -18,18 +19,19 @@ describe('compliance handler integration tests', function () {
 
         await handler(message);
 
-        const result = await db.get()('remediation_issue_systems')
-        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96bb' })
-        .where({ remediation_issue_id: '2'});
+        const result = await db.get()(RemediationIssueSystems.TABLE)
+        .join(RemediationIssues.TABLE, RemediationIssues.id, RemediationIssueSystems.remediation_issue_id)
+        .where({ [RemediationIssueSystems.system_id]: 'dde971ae-0a39-4c2b-9041-a92e2d5a96bb' })
+        .where({ [RemediationIssues.issue_id]: 'ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_rsylog_enabled'});
 
         result[0].resolved.should.equal(true);
-        spy.callCount.should.equal(1);
+        spy.callCount.should.equal(2);
     });
 
     test('update multiple issues', async () => {
         const message = {
             topic: 'platform.remediation-updates.compliance',
-            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96bb", "issues": ["ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_disabled", "ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_rsylog_enabled"]}',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96bb", "issues": ["ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_rsylog_enabled"]}',
             offset: 0,
             partition: 58,
             highWaterOffset: 1,
@@ -40,13 +42,17 @@ describe('compliance handler integration tests', function () {
 
         await handler(message);
 
-        const result1 = await db.get()('remediation_issue_systems')
-        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96bb' })
-        .where({ remediation_issue_id: '2'});
+        const result1 = await db.get()(RemediationIssueSystems.TABLE)
+        .join(RemediationIssues.TABLE, RemediationIssues.id, RemediationIssueSystems.remediation_issue_id)
+        .where({ [RemediationIssueSystems.system_id]: 'dde971ae-0a39-4c2b-9041-a92e2d5a96bb' })
+        .where({ [RemediationIssues.issue_id]: 'ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_rsylog_enabled'});
 
-        const result2 = await db.get()('remediation_issue_systems')
-        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96bb' })
-        .where({ remediation_issue_id: '7'});
+
+        const result2 = await db.get()(RemediationIssueSystems.TABLE)
+        .join(RemediationIssues.TABLE, RemediationIssues.id, RemediationIssueSystems.remediation_issue_id)
+        .where({ [RemediationIssueSystems.system_id]: 'dde971ae-0a39-4c2b-9041-a92e2d5a96bb' })
+        .where({ [RemediationIssues.issue_id]: 'ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_disabled'});
+
 
         result1[0].resolved.should.equal(false);
         result2[0].resolved.should.equal(true);
@@ -64,7 +70,7 @@ describe('compliance handler integration tests', function () {
             key: undefined
         };
 
-        const spy = getSandbox().spy(probes, 'complianceUpdateUnknown');
+        const spy = getSandbox().spy(probes, 'complianceHostUnknown');
 
         await handler(message);
         spy.callCount.should.equal(1);
@@ -80,10 +86,10 @@ describe('compliance handler integration tests', function () {
             key: undefined
         };
 
-        const spy = getSandbox().spy(probes, 'complianceUpdateUnknown');
+        const spy = getSandbox().spy(probes, 'complianceIssueUnknown');
 
         await handler(message);
-        spy.callCount.should.equal(1);
+        spy.callCount.should.equal(2);
     });
 
     test('handles database errors (search)', async () => {
@@ -97,13 +103,13 @@ describe('compliance handler integration tests', function () {
         };
 
         const spy = getSandbox().spy(probes, 'complianceUpdateError');
-        getSandbox().stub(db, 'findHostIssue').throws();
+        getSandbox().stub(db, 'findHostIssues').throws();
 
         await handler(message);
         spy.callCount.should.equal(1);
     });
 
-    test('handles database errors (update)', async () => {
+    test('handles database errors (updateUnresolved)', async () => {
         const message = {
             topic: 'platform.remediation-updates.compliance',
             value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96bb", "issues": ["ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_disabled"]}',
@@ -114,7 +120,24 @@ describe('compliance handler integration tests', function () {
         };
 
         const spy = getSandbox().spy(probes, 'complianceUpdateError');
-        getSandbox().stub(db, 'updateIssue').throws();
+        getSandbox().stub(db, 'updateToUnresolved').throws();
+
+        await handler(message);
+        spy.callCount.should.equal(1);
+    });
+
+    test('handles database errors (updateResolved)', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.compliance',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96bb", "issues": ["ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_disabled"]}',
+            offset: 0,
+            partition: 12,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'complianceUpdateError');
+        getSandbox().stub(db, 'updateToResolved').throws();
 
         await handler(message);
         spy.callCount.should.equal(1);

--- a/src/handlers/compliance/index.ts
+++ b/src/handlers/compliance/index.ts
@@ -38,19 +38,32 @@ export default async function onMessage (message: Message) {
     }
 
     const { host_id, issues } = parsed;
+    try {
+        const pastIssues = await db.findHostIssues(knex, host_id);
 
-    for (const issue of issues) {
-        try {
-            const searchResult = await db.findHostIssue(knex, host_id, issue);
-
-            if (searchResult.length > 0) {
-                const updateResult = await db.updateIssue(knex, host_id, searchResult[0].id);
-                probes.complianceUpdateSuccess(host_id, issue, updateResult);
-            } else {
-                probes.complianceUpdateUnknown(host_id, issue);
-            }
-        } catch (e) {
-            probes.complianceUpdateError(host_id, issue, e);
+        if (_.isEmpty(pastIssues)) {
+            probes.complianceHostUnknown(host_id);
+            return;
         }
+
+        for (const issue of pastIssues) {
+            if (_.find(issues, update => update === issue.issue_id)) {
+                const result = await db.updateToUnresolved(knex, host_id, issue.issue_id);
+
+                if (!_.isEmpty(result)) {
+                    probes.complianceIssueUnknown(host_id, issue.issue_id);
+                }
+                probes.complianceUpdateSuccess(host_id, issue.issue_id, result.length);
+            } else {
+                const result = await db.updateToResolved(knex, host_id, issue.issue_id);
+                
+                if (!_.isEmpty(result)) {
+                    probes.complianceIssueUnknown(host_id, issue.issue_id);
+                }
+                probes.complianceUpdateSuccess(host_id, issue.issue_id, result.length);
+            }
+        }
+    } catch (e) {
+        probes.complianceUpdateError(host_id, issues, e);
     }
 }

--- a/src/handlers/vulnerability/index.ts
+++ b/src/handlers/vulnerability/index.ts
@@ -38,19 +38,32 @@ export default async function onMessage (message: Message) {
     }
 
     const { host_id, issues } = parsed;
+    try {
+        const pastIssues = await db.findHostIssues(knex, host_id);
 
-    for (const issue of issues) {
-        try {
-            const searchResult = await db.findHostIssue(knex, host_id, issue);
-
-            if (searchResult.length > 0) {
-                const updateResult = await db.updateIssue(knex, host_id, searchResult[0].id);
-                probes.vulnerabilityUpdateSuccess(host_id, issue, updateResult);
-            } else {
-                probes.vulnerabilityUpdateUnknown(host_id, issue);
-            }
-        } catch (e) {
-            probes.vulnerabilityUpdateError(host_id, issue, e);
+        if (_.isEmpty(pastIssues)) {
+            probes.vulnerabilityHostUnknown(host_id);
+            return;
         }
+
+        for (const issue of pastIssues) {
+            if (_.find(issues, update => update === issue.issue_id)) {
+                const result = await db.updateToUnresolved(knex, host_id, issue.issue_id);
+
+                if (!_.isEmpty(result)) {
+                    probes.vulnerabilityIssueUnknown(host_id, issue.issue_id);
+                }
+                probes.vulnerabilityUpdateSuccess(host_id, issue.issue_id, result.length);
+            } else {
+                const result = await db.updateToResolved(knex, host_id, issue.issue_id);
+                
+                if (!_.isEmpty(result)) {
+                    probes.vulnerabilityIssueUnknown(host_id, issue.issue_id);
+                }
+                probes.vulnerabilityUpdateSuccess(host_id, issue.issue_id, result.length);
+            }
+        }
+    } catch (e) {
+        probes.vulnerabilityUpdateError(host_id, issues, e);
     }
 }

--- a/src/handlers/vulnerability/vulnerability.integration.ts
+++ b/src/handlers/vulnerability/vulnerability.integration.ts
@@ -1,3 +1,4 @@
+import { RemediationIssueSystems, RemediationIssues } from '../models';
 import { getSandbox } from '../../../test';
 import handler from '.';
 import * as db from '../../db';
@@ -18,18 +19,20 @@ describe('vulnerability handler integration tests', function () {
 
         await handler(message);
 
-        const result = await db.get()('remediation_issue_systems')
-        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96dd' })
-        .where({ remediation_issue_id: '4'});
+        const result = await db.get()(RemediationIssueSystems.TABLE)
+        .join(RemediationIssues.TABLE, RemediationIssues.id, RemediationIssueSystems.remediation_issue_id)
+        .where({ [RemediationIssueSystems.system_id]: 'dde971ae-0a39-4c2b-9041-a92e2d5a96dd' })
+        .where({ [RemediationIssues.issue_id]: 'vulnerabilities:CVE-2020-5719'});
+
 
         result[0].resolved.should.equal(true);
-        spy.callCount.should.equal(1);
+        spy.callCount.should.equal(2);
     });
 
     test('update multiple issues', async () => {
         const message = {
             topic: 'platform.remediation-updates.vulnerability',
-            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96dd", "issues": ["vulnerabilities:CVE-2018-5716", "vulnerabilities:CVE-2020-5719"]}',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96dd", "issues": ["vulnerabilities:CVE-2020-5719"]}',
             offset: 0,
             partition: 58,
             highWaterOffset: 1,
@@ -40,13 +43,15 @@ describe('vulnerability handler integration tests', function () {
 
         await handler(message);
 
-        const result1 = await db.get()('remediation_issue_systems')
-        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96dd' })
-        .where({ remediation_issue_id: '4'});
+        const result1 = await db.get()(RemediationIssueSystems.TABLE)
+        .join(RemediationIssues.TABLE, RemediationIssues.id, RemediationIssueSystems.remediation_issue_id)
+        .where({ [RemediationIssueSystems.system_id]: 'dde971ae-0a39-4c2b-9041-a92e2d5a96dd' })
+        .where({ [RemediationIssues.issue_id]: 'vulnerabilities:CVE-2020-5719'});
 
-        const result2 = await db.get()('remediation_issue_systems')
-        .where({ system_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96dd' })
-        .where({ remediation_issue_id: '9'});
+        const result2 = await db.get()(RemediationIssueSystems.TABLE)
+        .join(RemediationIssues.TABLE, RemediationIssues.id, RemediationIssueSystems.remediation_issue_id)
+        .where({ [RemediationIssueSystems.system_id]: 'dde971ae-0a39-4c2b-9041-a92e2d5a96dd' })
+        .where({ [RemediationIssues.issue_id]: 'vulnerabilities:CVE-2018-5716'});
 
         result1[0].resolved.should.equal(false);
         result2[0].resolved.should.equal(true);
@@ -64,7 +69,7 @@ describe('vulnerability handler integration tests', function () {
             key: undefined
         };
 
-        const spy = getSandbox().spy(probes, 'vulnerabilityUpdateUnknown');
+        const spy = getSandbox().spy(probes, 'vulnerabilityHostUnknown');
 
         await handler(message);
         spy.callCount.should.equal(1);
@@ -80,10 +85,10 @@ describe('vulnerability handler integration tests', function () {
             key: undefined
         };
 
-        const spy = getSandbox().spy(probes, 'vulnerabilityUpdateUnknown');
+        const spy = getSandbox().spy(probes, 'vulnerabilityIssueUnknown');
 
         await handler(message);
-        spy.callCount.should.equal(1);
+        spy.callCount.should.equal(2);
     });
 
     test('handles database errors (search)', async () => {
@@ -97,13 +102,13 @@ describe('vulnerability handler integration tests', function () {
         };
 
         const spy = getSandbox().spy(probes, 'vulnerabilityUpdateError');
-        getSandbox().stub(db, 'findHostIssue').throws();
+        getSandbox().stub(db, 'findHostIssues').throws();
 
         await handler(message);
         spy.callCount.should.equal(1);
     });
 
-    test('handles database errors (update)', async () => {
+    test('handles database errors (updateUnresolved)', async () => {
         const message = {
             topic: 'platform.remediation-updates.vulnerability',
             value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96dd", "issues": ["vulnerabilities:CVE-2018-5716"]}',
@@ -114,7 +119,24 @@ describe('vulnerability handler integration tests', function () {
         };
 
         const spy = getSandbox().spy(probes, 'vulnerabilityUpdateError');
-        getSandbox().stub(db, 'updateIssue').throws();
+        getSandbox().stub(db, 'updateToUnresolved').throws();
+
+        await handler(message);
+        spy.callCount.should.equal(1);
+    });
+
+    test('handles database errors (updateResolved)', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.vulnerability',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96dd", "issues": ["vulnerabilities:CVE-2018-5716"]}',
+            offset: 0,
+            partition: 12,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        const spy = getSandbox().spy(probes, 'vulnerabilityUpdateError');
+        getSandbox().stub(db, 'updateToResolved').throws();
 
         await handler(message);
         spy.callCount.should.equal(1);

--- a/src/kafka/index.ts
+++ b/src/kafka/index.ts
@@ -40,7 +40,11 @@ const consumer = P.promisifyAll(new kafka.ConsumerGroupStream({
     highWaterMark: 5
 }, [
     config.kafka.topics.inventory.topic,
-    config.kafka.topics.receptor.topic
+    config.kafka.topics.receptor.topic,
+    config.kafka.topics.advisor.topic,
+    config.kafka.topics.compliance.topic,
+    config.kafka.topics.patch.topic,
+    config.kafka.topics.vulnerability.topic
 ]));
 
 async function resetOffsets (topic: string) {
@@ -70,7 +74,11 @@ function connect (topicConfig: TopicConfig[]) {
         const offset = P.promisifyAll(consumer.consumerGroup.getOffset());
         const offsets = await offset.fetchLatestOffsetsAsync([
             config.kafka.topics.inventory.topic,
-            config.kafka.topics.receptor.topic
+            config.kafka.topics.receptor.topic,
+            config.kafka.topics.advisor.topic,
+            config.kafka.topics.compliance.topic,
+            config.kafka.topics.patch.topic,
+            config.kafka.topics.vulnerability.topic
         ]);
 
         log.debug(offsets, 'current offsets');

--- a/src/probes.ts
+++ b/src/probes.ts
@@ -30,11 +30,11 @@ const counters = {
 };
 
 // https://www.robustperception.io/existential-issues-with-metrics
-['success', 'unknown', 'error', 'error_parse'].forEach(value => counters.remove.labels(value).inc(0));
-['success', 'unknown', 'error', 'error_parse'].forEach(value => counters.advisor.labels(value).inc(0));
-['success', 'unknown', 'error', 'error_parse'].forEach(value => counters.compliance.labels(value).inc(0));
-['success', 'unknown', 'error', 'error_parse'].forEach(value => counters.patch.labels(value).inc(0));
-['success', 'unknown', 'error', 'error_parse'].forEach(value => counters.vulnerability.labels(value).inc(0));
+['success', 'unknown_host', 'unknown_issue', 'error', 'error_parse'].forEach(value => counters.remove.labels(value).inc(0));
+['success', 'unknown_host', 'unknown_issue', 'error', 'error_parse'].forEach(value => counters.advisor.labels(value).inc(0));
+['success', 'unknown_host', 'unknown_issue', 'error', 'error_parse'].forEach(value => counters.compliance.labels(value).inc(0));
+['success', 'unknown_host', 'unknown_issue', 'error', 'error_parse'].forEach(value => counters.patch.labels(value).inc(0));
+['success', 'unknown_host', 'unknown_issue', 'error', 'error_parse'].forEach(value => counters.vulnerability.labels(value).inc(0));
 ['error', 'error_parse', 'processed'].forEach(value => {
     ['playbook_run_ack', 'playbook_run_update', 'playbook_run_finished', 'playbook_run_cancel_ack', 'unknown'].forEach(type => {
         counters.receptor.labels(value, type).inc(0);
@@ -103,13 +103,18 @@ export function advisorUpdateSuccess (host_id: string, issue_id: string, referen
     counters.advisor.labels('success').inc();
 };
 
-export function advisorUpdateUnknown (host_id: string, issue_id: string) {
-    log.debug({ host_id, issue_id }, 'host_id or issue_id not known');
-    counters.advisor.labels('unknown').inc();
+export function advisorHostUnknown (host_id: string) {
+    log.debug({ host_id }, 'advisor host_id not known');
+    counters.advisor.labels('unknown_host').inc();
 };
 
-export function advisorUpdateError (host_id: string, issue_id: string, err: Error) {
-    log.error({ host_id, issue_id, err }, 'error updating advisor issue');
+export function advisorIssueUnknown (host_id: string, issue_id: string) {
+    log.debug({ host_id, issue_id }, 'advisor issue_id not known');
+    counters.advisor.labels('unknown_issue').inc();
+};
+
+export function advisorUpdateError (host_id: string, issues: Array<string>, err: Error) {
+    log.error({ host_id, issues, err }, 'error updating advisor issue');
     counters.advisor.labels('error').inc();
 };
 
@@ -123,13 +128,18 @@ export function complianceUpdateSuccess (host_id: string, issue_id: string, refe
     counters.compliance.labels('success').inc();
 };
 
-export function complianceUpdateUnknown (host_id: string, issue_id: string) {
-    log.debug({ host_id, issue_id }, 'host_id or issue_id not known');
-    counters.compliance.labels('unknown').inc();
+export function complianceHostUnknown (host_id: string) {
+    log.debug({ host_id }, 'compliance host_id not known');
+    counters.compliance.labels('unknown_host').inc();
 };
 
-export function complianceUpdateError (host_id: string, issue_id: string, err: Error) {
-    log.error({ host_id, issue_id, err }, 'error updating compliance issue');
+export function complianceIssueUnknown (host_id: string, issue_id: string) {
+    log.debug({ host_id, issue_id }, 'compliance issue_id not known');
+    counters.compliance.labels('unknown_issue').inc();
+};
+
+export function complianceUpdateError (host_id: string, issues: Array<string>, err: Error) {
+    log.error({ host_id, issues, err }, 'error updating compliance issue');
     counters.compliance.labels('error').inc();
 };
 
@@ -143,13 +153,18 @@ export function patchUpdateSuccess (host_id: string, issue_id: string, reference
     counters.patch.labels('success').inc();
 };
 
-export function patchUpdateUnknown (host_id: string, issue_id: string) {
-    log.debug({ host_id, issue_id }, 'host_id or issue_id not known');
-    counters.patch.labels('unknown').inc();
+export function patchHostUnknown (host_id: string) {
+    log.debug({ host_id }, 'patch host_id not known');
+    counters.patch.labels('unknown_host').inc();
 };
 
-export function patchUpdateError (host_id: string, issue_id: string, err: Error) {
-    log.error({ host_id, issue_id, err }, 'error updating patch issue');
+export function patchIssueUnknown (host_id: string, issue_id: string) {
+    log.debug({ host_id, issue_id }, 'patch issue_id not known');
+    counters.patch.labels('unknown_issue').inc();
+};
+
+export function patchUpdateError (host_id: string, issues: Array<string>, err: Error) {
+    log.error({ host_id, issues, err }, 'error updating patch issue');
     counters.patch.labels('error').inc();
 };
 
@@ -163,13 +178,18 @@ export function vulnerabilityUpdateSuccess (host_id: string, issue_id: string, r
     counters.vulnerability.labels('success').inc();
 };
 
-export function vulnerabilityUpdateUnknown (host_id: string, issue_id: string) {
-    log.debug({ host_id, issue_id }, 'host_id or issue_id not known');
-    counters.vulnerability.labels('unknown').inc();
+export function vulnerabilityHostUnknown (host_id: string) {
+    log.debug({ host_id }, 'vulnerability host_id not known');
+    counters.vulnerability.labels('unknown_host').inc();
 };
 
-export function vulnerabilityUpdateError (host_id: string, issue_id: string, err: Error) {
-    log.error({ host_id, issue_id, err }, 'error updating vulnerability issue');
+export function vulnerabilityIssueUnknown (host_id: string, issue_id: string) {
+    log.debug({ host_id, issue_id }, 'vulnerability issue_id not known');
+    counters.vulnerability.labels('unknown_issue').inc();
+};
+
+export function vulnerabilityUpdateError (host_id: string, issues: Array<string>, err: Error) {
+    log.error({ host_id, issues, err }, 'error updating vulnerability issue');
     counters.vulnerability.labels('error').inc();
 };
 

--- a/test/migrations/20207028110333_add_index_to_system_id.js
+++ b/test/migrations/20207028110333_add_index_to_system_id.js
@@ -1,0 +1,11 @@
+export function up (knex) {
+    return knex.schema.alterTable('remediation_issue_systems', function (table) {
+        table.index('system_id');
+    });
+}
+
+export function down (knex) {
+    return knex.schema.alterTable('remediation_issue_systems', function (table) {
+        table.dropIndex('system_id');
+    });
+}


### PR DESCRIPTION
With this change I hope to make the update handlers more efficient:

- The majority of updates coming in from apps will be no-ops for the remediation handlers so I added an initial call to check to see if the remediations_db knows of this host.  If it does it goes to work updating the issues, if not it moves on.
- Added an index to the **system_id** field in the remediation_issue_systems table to increase the call speed of the initial query.

Additionally I also reworked the handler logic to make more sense / added more precise probes for error checking.

google doc: https://docs.google.com/document/d/1UaTDxj0jK-VaAZYzpESIvCAhE5-ST8XZt63PP5dsOIw/edit
JIRA:  https://projects.engineering.redhat.com/browse/RHCLOUD-8016