### PR TITLE
RHCLOUD-8542: Create second consumer for application updates

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -170,6 +170,11 @@ const config = convict({
                     format: Boolean,
                     default: false,
                     env: 'ADVISOR_RESET_OFFSETS'
+                },
+                enabled: {
+                    format: Boolean,
+                    default: false,
+                    env: 'ADVISOR_TOPIC_ENABLED'
                 }
             },
             compliance: {
@@ -182,6 +187,11 @@ const config = convict({
                     format: Boolean,
                     default: false,
                     env: 'COMPLIANCE_RESET_OFFSETS'
+                },
+                enabled: {
+                    format: Boolean,
+                    default: false,
+                    env: 'COMPLIANCE_TOPIC_ENABLED'
                 }
             },
             inventory: {
@@ -194,6 +204,11 @@ const config = convict({
                     format: Boolean,
                     default: false,
                     env: 'INVENTORY_RESET_OFFSETS'
+                },
+                enabled: {
+                    format: Boolean,
+                    default: false,
+                    env: 'INVENTORY_TOPIC_ENABLED'
                 }
             },
             patch: {
@@ -206,6 +221,11 @@ const config = convict({
                     format: Boolean,
                     default: false,
                     env: 'PATCH_RESET_OFFSETS'
+                },
+                enabled: {
+                    format: Boolean,
+                    default: false,
+                    env: 'PATCH_TOPIC_ENABLED'
                 }
             },
             receptor: {
@@ -218,6 +238,11 @@ const config = convict({
                     format: Boolean,
                     default: false,
                     env: 'RECEPTOR_RESET_OFFSETS'
+                },
+                enabled: {
+                    format: Boolean,
+                    default: false,
+                    env: 'RECEPTOR_TOPIC_ENABLED'
                 }
             },
             vulnerability: {
@@ -230,6 +255,11 @@ const config = convict({
                     format: Boolean,
                     default: false,
                     env: 'VULNERABILITY_RESET_OFFSETS'
+                },
+                enabled: {
+                    format: Boolean,
+                    default: false,
+                    env: 'VULNERABILITY_TOPIC_ENABLED'
                 }
             }
         }

--- a/src/format.ts
+++ b/src/format.ts
@@ -8,17 +8,40 @@ import config from './config';
 
 export function formatTopicDetails(): TopicConfig[] {
     return [{
+        enabled: config.kafka.topics.inventory.enabled,
         topic: config.kafka.topics.inventory.topic,
         handler: inventoryHandler,
         resetOffsets: config.kafka.topics.inventory.resetOffsets
     }, {
+        enabled: config.kafka.topics.receptor.enabled,
         topic: config.kafka.topics.receptor.topic,
         handler: receptorHandler,
         resetOffsets: config.kafka.topics.receptor.resetOffsets
+    }, {
+        enabled: config.kafka.topics.advisor.enabled,
+        topic: config.kafka.topics.advisor.topic,
+        handler: advisorHandler,
+        resetOffsets: config.kafka.topics.advisor.resetOffsets
+    }, {
+        enabled: config.kafka.topics.compliance.enabled,
+        topic: config.kafka.topics.compliance.topic,
+        handler: complianceHandler,
+        resetOffsets: config.kafka.topics.compliance.resetOffsets
+    }, {
+        enabled: config.kafka.topics.patch.enabled,
+        topic: config.kafka.topics.patch.topic,
+        handler: patchHandler,
+        resetOffsets: config.kafka.topics.patch.resetOffsets
+    }, {
+        enabled: config.kafka.topics.vulnerability.enabled,
+        topic: config.kafka.topics.vulnerability.topic,
+        handler: vulnerabilityHandler,
+        resetOffsets: config.kafka.topics.vulnerability.resetOffsets
     }];
 }
 
 export interface TopicConfig {
+    enabled: boolean;
     topic: string;
     handler: any;
     resetOffsets: boolean;


### PR DESCRIPTION
Create second consumer for updates to Remediations.  This is a draft PR to show the work that has been done so far.

With this new change to the consumer, We are now able to distinguish which topics we want the consumer to read from by adding them as env variables.  All other topics (not included as env variables) will be ignored.  This will allow us to use the same source code for both consumers, specifying which topics should be read for each.

JIRA:  https://projects.engineering.redhat.com/browse/RHCLOUD-8542