### PR TITLE
RHCLOUD-5369: add playbook_run_completed response type

### DIFF
--- a/src/handlers/models.ts
+++ b/src/handlers/models.ts
@@ -50,5 +50,7 @@ export enum PlaybookRunSystem {
     status = 'status',
     system_name = 'system_name',
     console = 'console',
-    updated_at = 'updated_at'
+    updated_at = 'updated_at',
+    connection_code = 'connection_code',
+    execution_code = 'execution_code'
 }

--- a/src/handlers/receptor/index.ts
+++ b/src/handlers/receptor/index.ts
@@ -8,6 +8,7 @@ import * as playbookRunAck from './playbookRunAck';
 import * as playbookRunUpdate from './playbookRunUpdate';
 import * as playbookRunFinished from './playbookRunFinished';
 import * as playbookRunCancelAck from './playbookRunCancelAck';
+import * as playbookRunCompleted from './playbookRunCompleted';
 
 export interface ReceptorMessage<T> {
     account: string;
@@ -102,6 +103,11 @@ export default async function onMessage (message: Message) {
 
         case 'playbook_run_cancel_ack': {
             await handleSatResponse<playbookRunCancelAck.PlaybookRunCancelAck>(envelope, playbookRunCancelAck);
+            break;
+        }
+
+        case 'playbook_run_completed': {
+            await handleSatResponse<playbookRunCompleted.PlaybookRunCompleted>(envelope, playbookRunCompleted);
             break;
         }
 

--- a/src/handlers/receptor/playbookRunCompleted.ts
+++ b/src/handlers/receptor/playbookRunCompleted.ts
@@ -1,0 +1,85 @@
+import log from '../../util/log';
+import {SatReceptorResponse, ReceptorMessage} from '.';
+import * as assert from 'assert';
+import * as Joi from '@hapi/joi';
+import * as db from '../../db';
+import * as probes from '../../probes';
+import * as Knex from 'knex';
+import { Status } from '../models';
+import { findExecutorByReceptorIds, updateExecutorById } from './queries';
+import { tryUpdateRun } from './playbookRunFinished';
+
+const initialStatuses = [ Status.ACKED, Status.PENDING, Status.RUNNING ];
+
+export interface PlaybookRunCompleted extends SatReceptorResponse {
+    playbook_run_id: string;
+    status: string;
+    version: number;
+    satellite_connection_code: 0 | 1 | null;
+    satellite_connection_error: string | null;
+    satellite_infrastructure_code: 0 | 1 | null;
+    satellite_infrastructure_error: string | null;
+}
+
+export const schema = Joi.object().keys({
+    type: Joi.string().valid('playbook_run_completed').required(),
+    playbook_run_id: Joi.string().guid().required(),
+    status: Joi.string().valid('success', 'failure', 'canceled').required(),
+    version: Joi.number().required(),
+    satellite_connection_code: Joi.number().allow(null).required(),
+    satellite_connection_error: Joi.string().allow(null).required(),
+    satellite_infrastructure_code: Joi.number().allow(null).required(),
+    satellite_infrastructure_error: Joi.string().allow(null).required()
+});
+
+function tryUpdateExecutor (knex: Knex, executor_id: string, status: string) {
+    switch (status) {
+        case Status.SUCCESS: {
+            return updateExecutorById(knex, executor_id, initialStatuses, Status.SUCCESS);
+        }
+
+        case Status.FAILURE: {
+            return updateExecutorById(knex, executor_id, initialStatuses, Status.FAILURE);
+        }
+
+        case Status.CANCELED: {
+            return updateExecutorById(knex, executor_id, initialStatuses, Status.CANCELED);
+        }
+
+        default: {
+            log.debug({executor_id}, 'playbook_run_completed payload status was not a "finished" status');
+            return;
+        }
+    }
+}
+
+export async function handle (message: ReceptorMessage<PlaybookRunCompleted>) {
+    log.debug({message}, 'received playbook_run_completed');
+
+    const knex = db.get();
+
+    const executor = await findExecutorByReceptorIds(knex, message.in_response_to, message.sender);
+
+    if (!executor) {
+        probes.noExecutorFound(message.payload.type, {job_id: message.in_response_to, node_id: message.sender});
+        return;
+    }
+
+    const executorUpdated = await tryUpdateExecutor(knex, executor.id, message.payload.status);
+    if (!executorUpdated) {
+        log.debug('executor failed to update');
+        return;
+    }
+
+    assert.equal(executorUpdated, 1); // This should never be greater than one but just in case
+    log.info({id: executor.id, status: message.payload.status }, 'executor finished');
+
+    const runUpdated = await tryUpdateRun(knex, executor.playbook_run_id);
+    if (!runUpdated.length) {
+        log.debug('run not finished yet');
+        return;
+    }
+
+    assert.equal(runUpdated.length, 1); // it should never happen that this updates more than one row but just in case
+    log.info({id: runUpdated[0].id, status: runUpdated[0].status }, 'run finished');
+}

--- a/src/handlers/receptor/receptor.unit.ts
+++ b/src/handlers/receptor/receptor.unit.ts
@@ -33,6 +33,17 @@ const validCancel = JSON.stringify({
     status: 'cancelling'
 });
 
+const validCompleted = JSON.stringify({
+    type: 'playbook_run_completed',
+    playbook_run_id: '4b407690-e2f8-4563-96a6-6191f1df8901',
+    status: 'success',
+    version: 2,
+    satellite_connection_code: 0,
+    satellite_connection_error: null,
+    satellite_infrastructure_code: 0,
+    satellite_infrastructure_error: null
+});
+
 function createInvalidPayload (type: string): string {
     return JSON.stringify({ type });
 }
@@ -97,6 +108,14 @@ describe('receptor handler unit tests', function () {
         receptorErrorParse.callCount.should.equal(0);
     });
 
+    test('parses completed message', async () => {
+        const message = kafkaMessage(envelope(validCompleted));
+
+        await handler(message);
+        receptorError.callCount.should.equal(0);
+        receptorErrorParse.callCount.should.equal(0);
+    });
+
     test('throws error on invalid ack payload', async () => {
         const message = kafkaMessage(envelope(createInvalidPayload('playbook_run_ack')));
 
@@ -120,6 +139,13 @@ describe('receptor handler unit tests', function () {
 
     test('throws error on invalid cancel payload', async () => {
         const message = kafkaMessage(envelope(createInvalidPayload('playbook_run_cancel_ack')));
+
+        await handler(message);
+        receptorErrorParse.callCount.should.equal(1);
+    });
+
+    test('throws error on invalid completed payload', async () => {
+        const message = kafkaMessage(envelope(createInvalidPayload('playbook_run_completed')));
 
         await handler(message);
         receptorErrorParse.callCount.should.equal(1);

--- a/src/probes.ts
+++ b/src/probes.ts
@@ -36,11 +36,11 @@ const counters = {
 ['success', 'unknown_host', 'unknown_issue', 'error', 'error_parse'].forEach(value => counters.patch.labels(value).inc(0));
 ['success', 'unknown_host', 'unknown_issue', 'error', 'error_parse'].forEach(value => counters.vulnerability.labels(value).inc(0));
 ['error', 'error_parse', 'processed'].forEach(value => {
-    ['playbook_run_ack', 'playbook_run_update', 'playbook_run_finished', 'playbook_run_cancel_ack', 'unknown'].forEach(type => {
+    ['playbook_run_ack', 'playbook_run_update', 'playbook_run_finished', 'playbook_run_cancel_ack', 'playbook_run_completed', 'unknown'].forEach(type => {
         counters.receptor.labels(value, type).inc(0);
     });
 });
-['playbook_run_ack', 'playbook_run_update', 'playbook_run_finished'].forEach(value => counters.executorNotFound.labels(value).inc(0));
+['playbook_run_ack', 'playbook_run_update', 'playbook_run_finished', 'playbook_run_completed'].forEach(value => counters.executorNotFound.labels(value).inc(0));
 
 ['cancelling', 'finished', 'failure'].forEach(value => counters.receptorCancelAck.labels(value).inc(0));
 

--- a/test/migrations/20209113094846_define_connection_and_execution_code_for_system_level.js
+++ b/test/migrations/20209113094846_define_connection_and_execution_code_for_system_level.js
@@ -1,0 +1,13 @@
+export function up (knex) {
+    return knex.schema.alterTable('playbook_run_systems', function (table) {
+        table.integer('connection_code').nullable().defaultTo(null);
+        table.integer('execution_code').nullable().defaultTo(null);
+    });
+}
+
+export function down (knex) {
+    return knex.schema.alterTable('playbook_run_systems', function (table) {
+        table.dropColumn('connection_code');
+        table.dropColumn('execution_code');
+    });
+}

--- a/test/playbookRuns.ts
+++ b/test/playbookRuns.ts
@@ -90,11 +90,11 @@ export async function assertExecutor (id: string, status = Status.PENDING) {
     executor.status.should.equal(status);
 }
 
-export async function assertExecutorCodes (id: string, status = Status.PENDING, connection_code: any, execution_code: any) {
-    const executor = await getExecutor(id);
+export async function assertSystemStatusCodes (id: string, status = Status.PENDING, connection_code: any, execution_code: any) {
+    const system = await getSystem(id);
     if (status === Status.FAILURE && connection_code && execution_code) {
-        executor.connection_code.should.equal(connection_code)
-        executor.execution_code.should.equal(execution_code)
+        system.connection_code.should.equal(connection_code)
+        system.execution_code.should.equal(execution_code)
     }
 }
 


### PR DESCRIPTION
Add playbook_run_completed response type to remediations consumer.  Additionally updated the unit-tests and metrics to support the new response type.

JIRA:  https://issues.redhat.com/browse/RHCLOUD-5369
Satellite Contract V2: https://docs.google.com/document/d/1iJk62oxCpKtbnbm75D-ScLgWu1ygIfjwbad1YWC6Fh8/edit#