### PR TITLE
RHCLOUD-15156:  Update cleaner logic to ignore playbook_runs created for RHC runs

### DIFF
--- a/src/handlers/receptor/sharedQueries.ts
+++ b/src/handlers/receptor/sharedQueries.ts
@@ -57,6 +57,10 @@ export function whereUnfinishedExecutorsWithFinishedSystems (knex: Knex) {
 export function whereUnfinishedRunsWithFinishedExecutors (knex: Knex) {
     return knex(PlaybookRun.TABLE)
     .whereNotIn(PlaybookRun.status, FINAL_STATES)
+    .whereExists(
+        knex(PlaybookRunExecutor.TABLE)
+        .where(PlaybookRunExecutor.playbook_run_id, knex.raw('"playbook_runs"."id"'))
+    )
     .whereNotExists(
         knex(PlaybookRunExecutor.TABLE)
         .whereIn(PlaybookRunExecutor.status, NON_FINAL_STATES_EXECUTORS)

--- a/test/seeds/playbook_runs.js
+++ b/test/seeds/playbook_runs.js
@@ -17,6 +17,13 @@ export async function seed (knex) {
         created_by: 'fifi',
         created_at: '2019-12-23T08:19:36.641Z',
         updated_at: '2019-12-23T08:19:36.641Z'
+    }, {
+        id: '99d0ba73-0015-4e7d-a6d6-4b530cbfb6cb',
+        status: 'running',
+        remediation_id: '147b453d-36be-4c72-8dff-f1d24587ff73',
+        created_by: 'fifi',
+        created_at: '2019-12-23T08:19:36.641Z',
+        updated_at: '2019-12-23T08:19:36.641Z'
     }]);
 
     await knex('playbook_run_executors').insert([{


### PR DESCRIPTION
Update cleaner logic to ignore playbook_runs created for RHC runs.

JIRA:  https://issues.redhat.com/browse/RHCLOUD-15156    
    
    
    ## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices