### PR TITLE
Add kafka ssl configs

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -294,7 +294,7 @@ const config = convict({
             username: {
                 format: String,
                 default: '',
-                env: 'KAFKA_SASL_USERNAME',
+                env: 'KAFKA_SASL_USERNAME'
             },
             password: {
                 format: String,
@@ -383,7 +383,7 @@ if (acgConfig) {
 
     data.kafka.ssl = {
         ca: tmpobj2.name
-    }
+    };
 
     config.load(data);
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -271,6 +271,37 @@ const config = convict({
                     env: 'VULNERABILITY_TOPIC_ENABLED'
                 }
             }
+        },
+        ssl: {
+            enabled: {
+                format: Boolean,
+                default: false,
+                env: 'KAFKA_SSL_ENABLED'
+            },
+            ca: {
+                format: String,
+                default: '',
+                env: 'KAFKA_CA',
+                sensitive: true
+            }
+        },
+        sasl: {
+            mechanism: {
+                format: String,
+                default: 'plain',
+                env: 'KAFKA_SASL_MECHANISM'
+            },
+            username: {
+                format: String,
+                default: '',
+                env: 'KAFKA_SASL_USERNAME',
+            },
+            password: {
+                format: String,
+                default: '',
+                env: 'KAFKA_SASL_PASSWORD',
+                sensitive: true
+            }
         }
     },
 
@@ -339,8 +370,20 @@ if (acgConfig) {
     // Kafka settings
     data.kafka = {
         host: clowdAppConfig.kafka.brokers[0].hostname,
-        port: clowdAppConfig.kafka.brokers[0].port.toString()
+        port: clowdAppConfig.kafka.brokers[0].port.toString(),
+        sasl: {
+            username: clowdAppConfig.kafka.brokers[0].sasl.username,
+            password: clowdAppConfig.kafka.brokers[0].sasl.password
+        }
     };
+
+    const tmpobj2 = tmp.fileSync({mode: 0o644, prefix: 'prefix-', postfix: '.txt'});
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    fs.writeFileSync(tmpobj2.name, clowdAppConfig.database.rdsCa, 'utf8');
+
+    data.kafka.ssl = {
+        ca: tmpobj2.name
+    }
 
     config.load(data);
 }

--- a/src/kafka/index.ts
+++ b/src/kafka/index.ts
@@ -46,6 +46,23 @@ const pinoLogCreator = (logLevel: logLevel) => {
 };
 
 function configureBroker () {
+    if (config.kafka.ssl.enabled) {
+        return new Kafka({
+            logLevel: kafkaLogLevel(),
+            logCreator: pinoLogCreator,
+            brokers: [`${config.kafka.host}:${config.kafka.port}`],
+            ssl: {
+                rejectUnauthorized: false,
+                ca: [config.kafka.ssl.ca]
+            },
+            sasl: {
+                mechanism: 'scram-sha-512',
+                username: config.kafka.sasl.username,
+                password: config.kafka.sasl.password
+            }
+        });
+    }
+
     return new Kafka({
         logLevel: kafkaLogLevel(),
         logCreator: pinoLogCreator,


### PR DESCRIPTION
Added Kafka ssl configs to remediations-consumer config based on the format stated in the kafkajs documentation:
KafkaJS DOCS:  https://kafka.js.org/docs/next/configuration#sasl

With this change, all of the remediations services should be available in the FedRAMP STAGE cluster.

JIRA:  https://issues.redhat.com/browse/RHCLOUD-16207
PARENT JIRA: https://issues.redhat.com/browse/RHCLOUD-15728    
    
    
    ## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices