### PR TITLE
Add new npm run target for pr checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint": "eslint src/**/*.ts test/**/*.js",
     "start": "tsc && LOG_PRETTY=true node dist/src/app.js",
     "test": "tsc && npm run db:ims && NODE_ENV=test LOG_LEVEL=fatal jest -i",
+    "test-jenkins": "tsc && npm run db:seed && NODE_ENV=test LOG_LEVEL=fatal jest -i",
     "verify": "npm-run-all lint coverage"
   },
   "author": "Jozef Hartinger",

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -16,7 +16,7 @@ echo DB_PORT:     $DB_PORT
 
 # run unit-tests
 npm ci
-npm run test
+npm run test-jenkins
 result=$?
 
 # TODO: add unittest-xml-reporting to rbac so that junit results can be parsed by jenkins


### PR DESCRIPTION
When running in a Jenkins pr check, do not init/migrate the DB, only seed.