### PR TITLE
Set dependabot to check for updates on Sundays

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,11 @@ updates:
     directory: "/build"
     schedule:
       interval: "weekly"
+      day: "sunday"
 
   # Check for updates to NPM packages
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "sunday"


### PR DESCRIPTION
Make dependabot run on Sundays so we can schedule any updates for the week on Monday mornings,