### PR TITLE
RHINENG-9085: Stop listening for receptor kafka topics

### DIFF
--- a/deployment/remediations-consumer-clowdapp.yaml
+++ b/deployment/remediations-consumer-clowdapp.yaml
@@ -18,9 +18,6 @@ objects:
     - replicas: 64
       partitions: 64
       topicName: platform.inventory.events
-    - replicas: 3
-      partitions: 3
-      topicName: platform.receptor-controller.responses
     deployments:
     - name: remediations-consumer
       minReplicas: ${{NUM_REPLICAS}}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -417,10 +417,6 @@ if (acgConfig) {
             topic: processTopicName(clowdAppConfig, 'platform.remediation-updates.patch'),
             enabled: processTopicEnabled(clowdAppConfig, 'platform.remediation-updates.patch')
         },
-        receptor: {
-            topic: processTopicName(clowdAppConfig, 'platform.receptor-controller.responses'),
-            enabled: processTopicEnabled(clowdAppConfig, 'platform.receptor-controller.responses')
-        },
         vulnerability: {
             topic: processTopicName(clowdAppConfig, 'platform.remediation-updates.vulnerability'),
             enabled: processTopicEnabled(clowdAppConfig, 'platform.remediation-updates.vulnerability')

--- a/src/format.ts
+++ b/src/format.ts
@@ -13,11 +13,6 @@ export function formatTopicDetails(): TopicConfig[] {
         handler: inventoryHandler,
         resetOffsets: config.kafka.topics.inventory.resetOffsets
     }, {
-        enabled: config.kafka.topics.receptor.enabled,
-        topic: config.kafka.topics.receptor.topic,
-        handler: receptorHandler,
-        resetOffsets: config.kafka.topics.receptor.resetOffsets
-    }, {
         enabled: config.kafka.topics.advisor.enabled,
         topic: config.kafka.topics.advisor.topic,
         handler: advisorHandler,


### PR DESCRIPTION
Just stop listening to receptor topics for now.  We can revisit removing receptor support altogether at a later date.