### PR TITLE
Updates for metrics URL settign and checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 sonar-scanner.properties
 .scannerwork/
 artifacts
+.idea

--- a/deployment/remediations-consumer-clowdapp.yaml
+++ b/deployment/remediations-consumer-clowdapp.yaml
@@ -98,10 +98,10 @@ objects:
             value: ${LOG_LEVEL}
           - name: METRICS_PREFIX
             value: remediations_cleaner_
-          - name: METRICS_GW_PROTOCOL
+          - name: METRICS_GW_SCHEME
             value: 'http://'
           - name: METRICS_PUSH_GATEWAY
-            value: ${METRICS_GW_PROTOCOL}${PROMETHEUS_PUSHGATEWAY}
+            value: ${METRICS_GW_SCHEME}${PROMETHEUS_PUSHGATEWAY}
           - name: METRICS_PUSH_GATEWAY_ENABLED
             value: ${METRICS_PUSH_GATEWAY_ENABLED}
         resources:

--- a/deployment/remediations-consumer-clowdapp.yaml
+++ b/deployment/remediations-consumer-clowdapp.yaml
@@ -98,8 +98,10 @@ objects:
             value: ${LOG_LEVEL}
           - name: METRICS_PREFIX
             value: remediations_cleaner_
+          - name: METRICS_GW_PROTOCOL
+            value: 'http://'
           - name: METRICS_PUSH_GATEWAY
-            value: http://${PROMETHEUS_PUSHGATEWAY}
+            value: ${METRICS_GW_PROTOCOL}${PROMETHEUS_PUSHGATEWAY}
           - name: METRICS_PUSH_GATEWAY_ENABLED
             value: ${METRICS_PUSH_GATEWAY_ENABLED}
         resources:
@@ -146,6 +148,8 @@ parameters:
   name: IMAGE_TAG
   required: true
 - name: PROMETHEUS_PUSHGATEWAY
+- name: METRICS_PUSH_GATEWAY
+  value: 'http://localhost:9091'
 - name: METRICS_PUSH_GATEWAY_ENABLED
   value: 'true'
 - description: Cpu limit of cleaner job

--- a/src/cleaner/probes.ts
+++ b/src/cleaner/probes.ts
@@ -41,11 +41,12 @@ export async function pushMetrics () {
         const asyncGateway = P.promisifyAll(gateway);
 
         const jobName = `${config.namespace}|${os.hostname}`;
-        logger.info({jobName}, 'pushing metrics');
-
         const resp = await asyncGateway.pushAsync({jobName});
         if (resp.statusCode !== 200) {
             throw new Error(`failed to push metrics ${resp.statusCode}`);
         }
+        log.info('metrics sent');
+    } else {
+        log.info(`metrics not enabled(METRICS_PUSH_GATEWAY_ENABLED = ${config.metrics.pushGatewayEnabled})`);
     }
 }

--- a/src/cleaner/run.ts
+++ b/src/cleaner/run.ts
@@ -18,7 +18,6 @@ async function run () {
     } finally {
         try {
             await probes.pushMetrics();
-            log.info('metrics sent');
         } finally {
             await stop();
         }


### PR DESCRIPTION
This PR changes the following:

- add ability to change scheme for METRICS_PUSH_GATEWAY

- move enable metrics log message
The following is seen in the logs even when metrics is disabled:
```
{"level":30,"time":1711990810254,"pid":1,"hostname":"remediations-consumer-cleaner-28533180-mlrfg","name":"remediations-consumer","type":"application","msg":"metrics sent","v":1}
```
I have fixed this by moving the log message and now logging the above only when metrics are truely sent, and log a message showing that the sending of metrics is disabled.

