### PR TITLE
Change image for cleaner job

### DIFF
--- a/deployment/remediations-consumer-clowdapp.yaml
+++ b/deployment/remediations-consumer-clowdapp.yaml
@@ -84,7 +84,7 @@ objects:
       schedule: '@hourly'
       suspend: ${{CLEANER_SUSPEND}}
       podSpec:
-        image: quay.io/cloudservices/remediations-consumer:${IMAGE_TAG}
+        image: ${IMAGE}:${IMAGE_TAG}
         restartPolicy: Never
         command:
           - node


### PR DESCRIPTION
Today when @skateman showed me changes made for Konflux migration, he noticed cleaner job should also use image from redhat-services-prod.