### PR TITLE
RHINENG-18476: Handle 'create' playbook run events

### DIFF
--- a/src/kafka/index.ts
+++ b/src/kafka/index.ts
@@ -91,14 +91,8 @@ function connect () {
 
 export async function start (topicConfig: TopicConfig[]) {
     const {consumer, stop} = await connect();
-    log.warn('Full topicConfig:', JSON.stringify(topicConfig, null, 2));
 
-    const topics = topicConfig.map(topic => {
-        if (!topic.topic) {
-            log.warn(`Topic entry missing 'topic' field: ${JSON.stringify(topic)}`);
-        }
-        return topic.topic;
-    });
+    const topics = topicConfig.map(topic => { return topic.topic; });
     log.info('TOPICS ENABLED', topics);
 
     await consumer.connect();
@@ -106,11 +100,6 @@ export async function start (topicConfig: TopicConfig[]) {
 
     // Subscribe to each enabled topic
     for (const topic of topicConfig) {
-        if (!topic.topic) {
-            log.warn(`Attempting to subscribe to an undefined topic: ${JSON.stringify(topic)}`);
-            continue;
-        }
-
         await consumer.subscribe({ topic: topic.topic });
     }
 

--- a/src/probes.ts
+++ b/src/probes.ts
@@ -209,8 +209,13 @@ export function vulnerabilityUpdateErrorParse (message: Message, err: Error) {
 };
 
 export function playbookUpdateSuccess(run_id: string, status: 'success' | 'failure' | 'running' | 'timeout' | 'canceled') {
-    log.info({ run_id, status }, `playbook run ${status}`);
+    log.info({ run_id, status }, `playbook run status updated on update ${status}`);
     counters.playbookRuns.labels('updated', status).inc();
+}
+
+export function playbookCreateSuccess(run_id: string, status: 'success' | 'failure' | 'running' | 'timeout' | 'canceled') {
+    log.info({ run_id, status }, `playbook run status updated on create ${status}`);
+    counters.playbookRuns.labels('created', status).inc();
 }
 
 export function playbookRunUnknown(run_id: string, status: string) {


### PR DESCRIPTION
 Removing logging code that was used for debugging and added code to handle 'create' Kafka events from playbook-dispatcher

 ## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices