### PR TITLE
RHINENG-21568: Add new systems columns and track updates

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -153,7 +153,9 @@ export async function updateSystem(
     id: string,
     hostname?: string,
     display_name?: string,
-    ansible_hostname?: string
+    ansible_hostname?: string,
+    satellite_org_id?: string,
+    owner_id?: string
 ) {
     const now = new Date();
 
@@ -163,6 +165,8 @@ export async function updateSystem(
     if (hostname) updateFields.hostname = hostname;
     if (display_name) updateFields.display_name = display_name;
     if (ansible_hostname) updateFields.ansible_hostname = ansible_hostname;
+    if (satellite_org_id) updateFields.satellite_org_id = satellite_org_id;
+    if (owner_id) updateFields.owner_id = owner_id;
 
     await knex('systems')
         .where({ id })

--- a/src/handlers/inventory/index.ts
+++ b/src/handlers/inventory/index.ts
@@ -11,6 +11,11 @@ interface RemoveMessage {
     type: string;
 }
 
+interface FactNamespace {
+    namespace: string;
+    facts: Record<string, unknown>;
+}
+
 interface UpdateMessage {
     type: 'updated';
     host: {
@@ -18,6 +23,10 @@ interface UpdateMessage {
         display_name?: string;
         ansible_host?: string;
         fqdn?: string;
+        facts?: FactNamespace[];
+        system_profile?: {
+            owner_id?: string;
+        };
     };
 }
 
@@ -32,7 +41,16 @@ const updateMessageSchema = Joi.object().keys({
         id: Joi.string().uuid().required(),
         display_name: Joi.string().allow(null).optional(),
         ansible_host: Joi.string().allow(null).optional(),
-        fqdn: Joi.string().allow(null).optional()
+        fqdn: Joi.string().allow(null).optional(),
+        facts: Joi.array().items(
+            Joi.object().keys({
+                namespace: Joi.string().required(),
+                facts: Joi.object().unknown(true).required()
+            })
+        ).optional(),
+        system_profile: Joi.object().keys({
+            owner_id: Joi.string().allow(null).optional()
+        }).unknown(true).optional()
     }).required()
 });
 
@@ -101,12 +119,20 @@ async function handleUpdateEvent(event: UpdateMessage) {
         // - fqdn: hostname (DNS identity)
         // - display_name: display_name (human-friendly name)
         // - ansible_host: ansible_hostname (connectivity address)
+        // - facts[namespace=satellite].facts.organization_id: satellite_org_id
+        // - system_profile.owner_id: owner_id
+        const satelliteFacts = host.facts?.find(f => f.namespace === 'satellite');
+        const satelliteOrgId = satelliteFacts?.facts?.organization_id as string | undefined;
+        const ownerId = host.system_profile?.owner_id;
+
         await db.updateSystem(
             knex,
             host.id,
             host.fqdn,
             host.display_name,
-            host.ansible_host
+            host.ansible_host,
+            satelliteOrgId,
+            ownerId
         );
 
         probes.inventoryUpdateSuccess(host.id);

--- a/src/handlers/inventory/inventory.unit.ts
+++ b/src/handlers/inventory/inventory.unit.ts
@@ -182,6 +182,108 @@ describe('inventory handler unit tests', function () {
             await handler(message);
             inventoryErrorParse.callCount.should.equal(1);
         });
+
+        test('parses message with satellite_org_id and owner_id', async () => {
+            const message = {
+                topic: 'platform.inventory.events',
+                value: JSON.stringify({
+                    "type": "updated",
+                    "timestamp": "2019-05-23T18:31:39.065368+00:00",
+                    "host": {
+                        "id": "6cfa75ee-5ba9-442e-9557-6dbbf33593c4",
+                        "display_name": "test-host",
+                        "fqdn": "test-host.example.com",
+                        "ansible_host": "test-host-ansible",
+                        "facts": [
+                            {
+                                "namespace": "satellite",
+                                "facts": {
+                                    "organization_id": "sat-org-123"
+                                }
+                            }
+                        ],
+                        "system_profile": {
+                            "owner_id": "owner-456"
+                        }
+                    }
+                }),
+                offset: 0,
+                partition: 58,
+                highWaterOffset: 1,
+                key: undefined
+            };
+
+            await handler(message);
+            inventoryErrorParse.callCount.should.equal(0);
+        });
+
+        test('parses message with multiple fact namespaces', async () => {
+            const message = {
+                topic: 'platform.inventory.events',
+                value: JSON.stringify({
+                    "type": "updated",
+                    "timestamp": "2019-05-23T18:31:39.065368+00:00",
+                    "host": {
+                        "id": "6cfa75ee-5ba9-442e-9557-6dbbf33593c4",
+                        "display_name": "test-host",
+                        "facts": [
+                            {
+                                "namespace": "satellite",
+                                "facts": {
+                                    "organization_id": "sat-org-123",
+                                    "virtual_host_uuid": "some-uuid"
+                                }
+                            },
+                            {
+                                "namespace": "rhsm",
+                                "facts": {
+                                    "some_field": "some_value"
+                                }
+                            }
+                        ]
+                    }
+                }),
+                offset: 0,
+                partition: 58,
+                highWaterOffset: 1,
+                key: undefined
+            };
+
+            await handler(message);
+            inventoryErrorParse.callCount.should.equal(0);
+        });
+
+        test('parses message without satellite facts', async () => {
+            const message = {
+                topic: 'platform.inventory.events',
+                value: JSON.stringify({
+                    "type": "updated",
+                    "timestamp": "2019-05-23T18:31:39.065368+00:00",
+                    "host": {
+                        "id": "6cfa75ee-5ba9-442e-9557-6dbbf33593c4",
+                        "display_name": "test-host",
+                        "facts": [
+                            {
+                                "namespace": "rhsm",
+                                "facts": {
+                                    "some_field": "some_value"
+                                }
+                            }
+                        ],
+                        "system_profile": {
+                            "owner_id": "owner-456"
+                        }
+                    }
+                }),
+                offset: 0,
+                partition: 58,
+                highWaterOffset: 1,
+                key: undefined
+            };
+
+            await handler(message);
+            inventoryErrorParse.callCount.should.equal(0);
+        });
     });
 
     describe('unsupported events', () => {

--- a/test/migrations/20260310120000_add_satellite_org_id_and_owner_id_to_systems.js
+++ b/test/migrations/20260310120000_add_satellite_org_id_and_owner_id_to_systems.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+    return knex.schema.alterTable('systems', function (table) {
+        table.string('satellite_org_id', 50).nullable();
+        table.string('owner_id', 50).nullable();
+    });
+};
+
+exports.down = function(knex) {
+    return knex.schema.alterTable('systems', function (table) {
+        table.dropColumn('satellite_org_id');
+        table.dropColumn('owner_id');
+    });
+};


### PR DESCRIPTION
## Summary by Sourcery

Track additional system metadata from inventory update events and persist it on systems records.

New Features:
- Store Satellite organization ID and owner ID on systems based on incoming inventory update events.

Enhancements:
- Extend inventory update message schema and handler to accept satellite facts and system profile owner ID.
- Update database update helper to conditionally write new satellite_org_id and owner_id columns.

Tests:
- Add unit tests ensuring inventory handler correctly parses satellite facts, owner ID, and various fact namespace combinations.

## My summary (for more info)

This PR changes how we fetch system details when viewing remediations and generating playbooks. Instead of always calling the Inventory API, we now:
- Query the local systems table first - System details are already stored when systems are added to remediations
- Fallback to Inventory API for missing systems - If a system isn't in the local table, we fetch from Inventory and store it for future requests
- Backfill logic for satellite_org_id and owner_id - For satellite filtering and cert-auth validation, if these columns are null (never checked), we fetch from Inventory and cache the result. We use '' to indicate "checked but no value" to avoid repeated API calls.
 
Affected endpoints:
- GET /remediations/{id} - Uses local table for system hostnames/display names
- GET /remediations/{id}/playbook - Uses local table for satellite filtering and cert-auth validation

Benefits:
- Reduces Inventory API calls
- Faster response times for cached systems