### PR TITLE
RHINENG-26412: fixed joi validation schemas and added edge case tests

### DIFF
--- a/src/handlers/advisor/advisor.unit.ts
+++ b/src/handlers/advisor/advisor.unit.ts
@@ -64,4 +64,19 @@ describe('advisor handler unit tests', function () {
         await handler(message);
         advisorUpdateErrorParse.callCount.should.equal(1);
     });
+
+    test('handles empty issues array', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.advisor',
+            value: '{"host_id": "47c686b1-c359-44a9-bd2f-1c111c0533db", "issues": []}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        // Empty issues array should be valid - parse error should NOT be called
+        advisorUpdateErrorParse.callCount.should.equal(0);
+    });
 });

--- a/src/handlers/advisor/advisor.unit.ts
+++ b/src/handlers/advisor/advisor.unit.ts
@@ -79,4 +79,122 @@ describe('advisor handler unit tests', function () {
         // Empty issues array should be valid - parse error should NOT be called
         advisorUpdateErrorParse.callCount.should.equal(0);
     });
+
+    test('handles advisor issue with plus sign', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.advisor',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc", "issues": ["advisor:CVE+2017+6074_kernel|KERNEL_CVE_2017_6074"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        advisorUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('handles large number of issues', async () => {
+        const issues = Array(2839).fill('advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074');
+        const message = {
+            topic: 'platform.remediation-updates.advisor',
+            value: JSON.stringify({
+                host_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc',
+                issues
+            }),
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        advisorUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('handles exactly 5000 issues (at limit)', async () => {
+        const issues = Array(5000).fill('advisor:test-issue');
+        const message = {
+            topic: 'platform.remediation-updates.advisor',
+            value: JSON.stringify({
+                host_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc',
+                issues
+            }),
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        advisorUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('rejects 5001 issues (over limit)', async () => {
+        const issues = Array(5001).fill('advisor:test-issue');
+        const message = {
+            topic: 'platform.remediation-updates.advisor',
+            value: JSON.stringify({
+                host_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc',
+                issues
+            }),
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        advisorUpdateErrorParse.callCount.should.equal(1);
+    });
+
+    test('handles issue ID with exactly 500 characters', async () => {
+        const longIssue = 'advisor:' + 'x'.repeat(492);
+        const message = {
+            topic: 'platform.remediation-updates.advisor',
+            value: JSON.stringify({
+                host_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc',
+                issues: [longIssue]
+            }),
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        advisorUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('rejects issue ID with 501 characters', async () => {
+        const tooLongIssue = 'advisor:' + 'x'.repeat(493);
+        const message = {
+            topic: 'platform.remediation-updates.advisor',
+            value: JSON.stringify({
+                host_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc',
+                issues: [tooLongIssue]
+            }),
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        advisorUpdateErrorParse.callCount.should.equal(1);
+    });
+
+    test('rejects UUID v1 format', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.advisor',
+            value: '{"host_id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8", "issues": ["advisor:test-issue"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        advisorUpdateErrorParse.callCount.should.equal(1);
+    });
 });

--- a/src/handlers/advisor/index.ts
+++ b/src/handlers/advisor/index.ts
@@ -22,7 +22,6 @@ const schema = Joi.object().keys({
             Joi.string()
                 .max(MAX_ISSUE_ID_LENGTH)
                 .regex(ISSUE_ID_PATTERN)
-                .required()
         )
         .min(0)
         .max(MAX_ISSUES_ARRAY_SIZE)

--- a/src/handlers/compliance/compliance.unit.ts
+++ b/src/handlers/compliance/compliance.unit.ts
@@ -64,4 +64,19 @@ describe('compliance handler unit tests', function () {
         await handler(message);
         complianceUpdateErrorParse.callCount.should.equal(1);
     });
+
+    test('handles empty issues array', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.compliance',
+            value: '{"host_id": "47c686b1-c359-44a9-bd2f-1c111c0533db", "issues": []}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        // Empty issues array should be valid - parse error should NOT be called
+        complianceUpdateErrorParse.callCount.should.equal(0);
+    });
 });

--- a/src/handlers/compliance/compliance.unit.ts
+++ b/src/handlers/compliance/compliance.unit.ts
@@ -79,4 +79,122 @@ describe('compliance handler unit tests', function () {
         // Empty issues array should be valid - parse error should NOT be called
         complianceUpdateErrorParse.callCount.should.equal(0);
     });
+
+    test('handles compliance issue with plus sign', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.compliance',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc", "issues": ["ssg:rhel8+profile+standard|xccdf_org.ssgproject.content_rule_test"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        complianceUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('handles large number of issues', async () => {
+        const issues = Array(2839).fill('ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_disabled');
+        const message = {
+            topic: 'platform.remediation-updates.compliance',
+            value: JSON.stringify({
+                host_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc',
+                issues
+            }),
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        complianceUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('handles exactly 5000 issues (at limit)', async () => {
+        const issues = Array(5000).fill('ssg:test-issue');
+        const message = {
+            topic: 'platform.remediation-updates.compliance',
+            value: JSON.stringify({
+                host_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc',
+                issues
+            }),
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        complianceUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('rejects 5001 issues (over limit)', async () => {
+        const issues = Array(5001).fill('ssg:test-issue');
+        const message = {
+            topic: 'platform.remediation-updates.compliance',
+            value: JSON.stringify({
+                host_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc',
+                issues
+            }),
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        complianceUpdateErrorParse.callCount.should.equal(1);
+    });
+
+    test('handles issue ID with exactly 500 characters', async () => {
+        const longIssue = 'ssg:' + 'x'.repeat(496);
+        const message = {
+            topic: 'platform.remediation-updates.compliance',
+            value: JSON.stringify({
+                host_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc',
+                issues: [longIssue]
+            }),
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        complianceUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('rejects issue ID with 501 characters', async () => {
+        const tooLongIssue = 'ssg:' + 'x'.repeat(497);
+        const message = {
+            topic: 'platform.remediation-updates.compliance',
+            value: JSON.stringify({
+                host_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc',
+                issues: [tooLongIssue]
+            }),
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        complianceUpdateErrorParse.callCount.should.equal(1);
+    });
+
+    test('rejects UUID v1 format', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.compliance',
+            value: '{"host_id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8", "issues": ["ssg:test-issue"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        complianceUpdateErrorParse.callCount.should.equal(1);
+    });
 });

--- a/src/handlers/compliance/index.ts
+++ b/src/handlers/compliance/index.ts
@@ -23,7 +23,6 @@ const schema = Joi.object().keys({
             Joi.string()
                 .max(MAX_ISSUE_ID_LENGTH)
                 .regex(ISSUE_ID_PATTERN)
-                .required()
         )
         .min(0)
         .max(MAX_ISSUES_ARRAY_SIZE)

--- a/src/handlers/patch/index.ts
+++ b/src/handlers/patch/index.ts
@@ -23,7 +23,6 @@ const schema = Joi.object().keys({
             Joi.string()
                 .max(MAX_ISSUE_ID_LENGTH)
                 .regex(ISSUE_ID_PATTERN)
-                .required()
         )
         .min(0)
         .max(MAX_ISSUES_ARRAY_SIZE)

--- a/src/handlers/patch/patch.unit.ts
+++ b/src/handlers/patch/patch.unit.ts
@@ -64,4 +64,137 @@ describe('patch handler unit tests', function () {
         await handler(message);
         patchUpdateErrorParse.callCount.should.equal(1);
     });
+
+    test('handles empty issues array', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.patch',
+            value: '{"host_id": "47c686b1-c359-44a9-bd2f-1c111c0533db", "issues": []}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        // Empty issues array should be valid - parse error should NOT be called
+        patchUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('handles RHEL module with plus sign in version', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.patch',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc", "issues": ["patch:buildah-2:1.33.10-1.module+el8.10.0+22397+e3c95ba6.x86_64"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        patchUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('handles 2839 issues (production example)', async () => {
+        const issues = Array(2839).fill('patch:kernel-0:4.18.0-553.100.1.el8_10.x86_64');
+        const message = {
+            topic: 'platform.remediation-updates.patch',
+            value: JSON.stringify({
+                host_id: '34ffef78-f014-493b-bab6-1228640cc608',
+                issues
+            }),
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        patchUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('handles exactly 5000 issues (at limit)', async () => {
+        const issues = Array(5000).fill('patch:test-0:1.0-1.el8.x86_64');
+        const message = {
+            topic: 'platform.remediation-updates.patch',
+            value: JSON.stringify({
+                host_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc',
+                issues
+            }),
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        patchUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('rejects 5001 issues (over limit)', async () => {
+        const issues = Array(5001).fill('patch:test-0:1.0-1.el8.x86_64');
+        const message = {
+            topic: 'platform.remediation-updates.patch',
+            value: JSON.stringify({
+                host_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc',
+                issues
+            }),
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        patchUpdateErrorParse.callCount.should.equal(1);
+    });
+
+    test('handles issue ID with exactly 500 characters', async () => {
+        const longIssue = 'patch:' + 'x'.repeat(494);
+        const message = {
+            topic: 'platform.remediation-updates.patch',
+            value: JSON.stringify({
+                host_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc',
+                issues: [longIssue]
+            }),
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        patchUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('rejects issue ID with 501 characters', async () => {
+        const tooLongIssue = 'patch:' + 'x'.repeat(495);
+        const message = {
+            topic: 'platform.remediation-updates.patch',
+            value: JSON.stringify({
+                host_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc',
+                issues: [tooLongIssue]
+            }),
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        patchUpdateErrorParse.callCount.should.equal(1);
+    });
+
+    test('rejects UUID v1 format', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.patch',
+            value: '{"host_id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8", "issues": ["patch:test-1.0"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        patchUpdateErrorParse.callCount.should.equal(1);
+    });
 });

--- a/src/handlers/vulnerability/index.ts
+++ b/src/handlers/vulnerability/index.ts
@@ -23,7 +23,6 @@ const schema = Joi.object().keys({
             Joi.string()
                 .max(MAX_ISSUE_ID_LENGTH)
                 .regex(ISSUE_ID_PATTERN)
-                .required()
         )
         .min(0)
         .max(MAX_ISSUES_ARRAY_SIZE)

--- a/src/handlers/vulnerability/vulnerability.unit.ts
+++ b/src/handlers/vulnerability/vulnerability.unit.ts
@@ -79,4 +79,122 @@ describe('vulnerability handler unit tests', function () {
         // Empty issues array should be valid - parse error should NOT be called
         vulnerabilityUpdateErrorParse.callCount.should.equal(0);
     });
+
+    test('handles vulnerability issue with plus sign', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.vulnerability',
+            value: '{"host_id": "dde971ae-0a39-4c2b-9041-a92e2d5a96cc", "issues": ["vulnerabilities:CVE+2018+5716"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        vulnerabilityUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('handles large number of issues', async () => {
+        const issues = Array(2839).fill('vulnerabilities:CVE-2018-5716');
+        const message = {
+            topic: 'platform.remediation-updates.vulnerability',
+            value: JSON.stringify({
+                host_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc',
+                issues
+            }),
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        vulnerabilityUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('handles exactly 5000 issues (at limit)', async () => {
+        const issues = Array(5000).fill('vulnerabilities:test-issue');
+        const message = {
+            topic: 'platform.remediation-updates.vulnerability',
+            value: JSON.stringify({
+                host_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc',
+                issues
+            }),
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        vulnerabilityUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('rejects 5001 issues (over limit)', async () => {
+        const issues = Array(5001).fill('vulnerabilities:test-issue');
+        const message = {
+            topic: 'platform.remediation-updates.vulnerability',
+            value: JSON.stringify({
+                host_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc',
+                issues
+            }),
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        vulnerabilityUpdateErrorParse.callCount.should.equal(1);
+    });
+
+    test('handles issue ID with exactly 500 characters', async () => {
+        const longIssue = 'vulnerabilities:' + 'x'.repeat(484);
+        const message = {
+            topic: 'platform.remediation-updates.vulnerability',
+            value: JSON.stringify({
+                host_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc',
+                issues: [longIssue]
+            }),
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        vulnerabilityUpdateErrorParse.callCount.should.equal(0);
+    });
+
+    test('rejects issue ID with 501 characters', async () => {
+        const tooLongIssue = 'vulnerabilities:' + 'x'.repeat(485);
+        const message = {
+            topic: 'platform.remediation-updates.vulnerability',
+            value: JSON.stringify({
+                host_id: 'dde971ae-0a39-4c2b-9041-a92e2d5a96cc',
+                issues: [tooLongIssue]
+            }),
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        vulnerabilityUpdateErrorParse.callCount.should.equal(1);
+    });
+
+    test('rejects UUID v1 format', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.vulnerability',
+            value: '{"host_id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8", "issues": ["vulnerabilities:test-issue"]}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        vulnerabilityUpdateErrorParse.callCount.should.equal(1);
+    });
 });

--- a/src/handlers/vulnerability/vulnerability.unit.ts
+++ b/src/handlers/vulnerability/vulnerability.unit.ts
@@ -64,4 +64,19 @@ describe('vulnerability handler unit tests', function () {
         await handler(message);
         vulnerabilityUpdateErrorParse.callCount.should.equal(1);
     });
+
+    test('handles empty issues array', async () => {
+        const message = {
+            topic: 'platform.remediation-updates.vulnerability',
+            value: '{"host_id": "47c686b1-c359-44a9-bd2f-1c111c0533db", "issues": []}',
+            offset: 0,
+            partition: 58,
+            highWaterOffset: 1,
+            key: undefined
+        };
+
+        await handler(message);
+        // Empty issues array should be valid - parse error should NOT be called
+        vulnerabilityUpdateErrorParse.callCount.should.equal(0);
+    });
 });

--- a/src/validation/issueId.ts
+++ b/src/validation/issueId.ts
@@ -1,8 +1,8 @@
 import log from '../util/log';
 
-export const ISSUE_ID_PATTERN = /^[a-zA-Z0-9_:|.\-\s]+$/;
+export const ISSUE_ID_PATTERN = /^[a-zA-Z0-9_:|.\-\s+]+$/;
 export const MAX_ISSUE_ID_LENGTH = 500;
-export const MAX_ISSUES_ARRAY_SIZE = 1000;
+export const MAX_ISSUES_ARRAY_SIZE = 5000;
 
 export function validateIssueId(issueId: string): boolean {
     if (typeof issueId !== 'string' || issueId.length === 0) {


### PR DESCRIPTION
## Summary by Sourcery

Relax Joi validation of remediation issue IDs and expand test coverage for edge cases in patch and other handlers.

Bug Fixes:
- Allow issue IDs containing plus signs to pass validation for patch messages.
- Permit empty issues arrays across patch, advisor, compliance, and vulnerability handlers.
- Increase the maximum allowed issues per message to align with production payload sizes and enforce rejection when over the limit.
- Ensure issue IDs are validated against a 500-character length limit, rejecting longer values.
- Reject invalid host UUID formats such as UUID v1 in patch messages.

Tests:
- Add patch handler tests for empty issue arrays, large issue counts, issue ID length boundaries, UUID format validation, and plus sign handling in versions.
- Add advisor, compliance, and vulnerability handler tests to confirm empty issues arrays are accepted.