### PR TITLE
RHINENG-26701: Bumped issues array limit up to 50,000

### DIFF
--- a/src/handlers/advisor/advisor.unit.ts
+++ b/src/handlers/advisor/advisor.unit.ts
@@ -112,8 +112,8 @@ describe('advisor handler unit tests', function () {
         advisorUpdateErrorParse.callCount.should.equal(0);
     });
 
-    test('handles exactly 5000 issues (at limit)', async () => {
-        const issues = Array(5000).fill('advisor:test-issue');
+    test('handles exactly 50000 issues (at limit)', async () => {
+        const issues = Array(50000).fill('advisor:test-issue');
         const message = {
             topic: 'platform.remediation-updates.advisor',
             value: JSON.stringify({
@@ -130,8 +130,8 @@ describe('advisor handler unit tests', function () {
         advisorUpdateErrorParse.callCount.should.equal(0);
     });
 
-    test('rejects 5001 issues (over limit)', async () => {
-        const issues = Array(5001).fill('advisor:test-issue');
+    test('rejects 50001 issues (over limit)', async () => {
+        const issues = Array(50001).fill('advisor:test-issue');
         const message = {
             topic: 'platform.remediation-updates.advisor',
             value: JSON.stringify({

--- a/src/handlers/compliance/compliance.unit.ts
+++ b/src/handlers/compliance/compliance.unit.ts
@@ -112,8 +112,8 @@ describe('compliance handler unit tests', function () {
         complianceUpdateErrorParse.callCount.should.equal(0);
     });
 
-    test('handles exactly 5000 issues (at limit)', async () => {
-        const issues = Array(5000).fill('ssg:test-issue');
+    test('handles exactly 50000 issues (at limit)', async () => {
+        const issues = Array(50000).fill('ssg:test-issue');
         const message = {
             topic: 'platform.remediation-updates.compliance',
             value: JSON.stringify({
@@ -130,8 +130,8 @@ describe('compliance handler unit tests', function () {
         complianceUpdateErrorParse.callCount.should.equal(0);
     });
 
-    test('rejects 5001 issues (over limit)', async () => {
-        const issues = Array(5001).fill('ssg:test-issue');
+    test('rejects 50001 issues (over limit)', async () => {
+        const issues = Array(50001).fill('ssg:test-issue');
         const message = {
             topic: 'platform.remediation-updates.compliance',
             value: JSON.stringify({

--- a/src/handlers/patch/patch.unit.ts
+++ b/src/handlers/patch/patch.unit.ts
@@ -112,8 +112,8 @@ describe('patch handler unit tests', function () {
         patchUpdateErrorParse.callCount.should.equal(0);
     });
 
-    test('handles exactly 5000 issues (at limit)', async () => {
-        const issues = Array(5000).fill('patch:test-0:1.0-1.el8.x86_64');
+    test('handles exactly 50000 issues (at limit)', async () => {
+        const issues = Array(50000).fill('patch:test-0:1.0-1.el8.x86_64');
         const message = {
             topic: 'platform.remediation-updates.patch',
             value: JSON.stringify({
@@ -130,8 +130,8 @@ describe('patch handler unit tests', function () {
         patchUpdateErrorParse.callCount.should.equal(0);
     });
 
-    test('rejects 5001 issues (over limit)', async () => {
-        const issues = Array(5001).fill('patch:test-0:1.0-1.el8.x86_64');
+    test('rejects 50001 issues (over limit)', async () => {
+        const issues = Array(50001).fill('patch:test-0:1.0-1.el8.x86_64');
         const message = {
             topic: 'platform.remediation-updates.patch',
             value: JSON.stringify({

--- a/src/handlers/vulnerability/vulnerability.unit.ts
+++ b/src/handlers/vulnerability/vulnerability.unit.ts
@@ -112,8 +112,8 @@ describe('vulnerability handler unit tests', function () {
         vulnerabilityUpdateErrorParse.callCount.should.equal(0);
     });
 
-    test('handles exactly 5000 issues (at limit)', async () => {
-        const issues = Array(5000).fill('vulnerabilities:test-issue');
+    test('handles exactly 50000 issues (at limit)', async () => {
+        const issues = Array(50000).fill('vulnerabilities:test-issue');
         const message = {
             topic: 'platform.remediation-updates.vulnerability',
             value: JSON.stringify({
@@ -130,8 +130,8 @@ describe('vulnerability handler unit tests', function () {
         vulnerabilityUpdateErrorParse.callCount.should.equal(0);
     });
 
-    test('rejects 5001 issues (over limit)', async () => {
-        const issues = Array(5001).fill('vulnerabilities:test-issue');
+    test('rejects 50001 issues (over limit)', async () => {
+        const issues = Array(50001).fill('vulnerabilities:test-issue');
         const message = {
             topic: 'platform.remediation-updates.vulnerability',
             value: JSON.stringify({

--- a/src/validation/issueId.ts
+++ b/src/validation/issueId.ts
@@ -2,7 +2,7 @@ import log from '../util/log';
 
 export const ISSUE_ID_PATTERN = /^[a-zA-Z0-9_:|.\-\s+]+$/;
 export const MAX_ISSUE_ID_LENGTH = 500;
-export const MAX_ISSUES_ARRAY_SIZE = 5000;
+export const MAX_ISSUES_ARRAY_SIZE = 50000;
 
 export function validateIssueId(issueId: string): boolean {
     if (typeof issueId !== 'string' || issueId.length === 0) {


### PR DESCRIPTION
## Summary by Sourcery

Increase the maximum supported issues array size across validation and related handlers.

Enhancements:
- Raise the global maximum issues array size limit from 5,000 to 50,000 to support larger remediation payloads.

Tests:
- Update advisor, compliance, patch, and vulnerability handler unit tests to cover the new 50,000-item limit and rejection of arrays exceeding that limit.